### PR TITLE
Make SmallVec::drop sound and other stuff

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,6 @@ readme = "README.md"
 name = "smallvec"
 path = "lib.rs"
 doctest = false
+
+[dependencies]
+nodrop = "0.1.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,3 @@ readme = "README.md"
 name = "smallvec"
 path = "lib.rs"
 doctest = false
-
-[dependencies]
-nodrop = "0.1.3"


### PR DESCRIPTION
* Use an enum so that we’re not dropping uninitialized `T` inside `[T; $size]`
* Move fields into that enum to make the struct smaller
* Refactor to be generic over array types rather than generate multiple `SmallVecN` types with macros.

r? @Manishearth