### PR TITLE
Fix panic safety issue in drop

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -578,4 +578,21 @@ pub mod tests {
 
         assert_eq!(&v.iter().map(|v| **v).collect::<Vec<_>>(), &[0, 3, 2]);
     }
+
+    #[test]
+    #[should_panic]
+    fn test_drop_panic_smallvec() {
+        // This test should only panic once, and not double panic,
+        // which would mean a double drop
+        struct DropPanic;
+
+        impl Drop for DropPanic {
+            fn drop(&mut self) {
+                panic!("drop");
+            }
+        }
+
+        let mut v = SmallVec::<[_; 1]>::new();
+        v.push(DropPanic);
+    }
 }


### PR DESCRIPTION
The summary is: SmallVec::drop first attempts to drop every element,
then it inhibits the drop of the inner array. The panic safety issue is
that a panic during drop of an element means the inhibition is never
reached, so the inner data can be dropped again.

If Drop is split betweeen SmallVec and SmallVecData, this issue is
avoided because the SmallVecData drop will be called even in the panic
case.

This solution incurs the overhead of an additional drop flag on
SmallVecData.

Fixes #14