### PR TITLE
Bring SmallVec closer to Vec

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -935,4 +935,69 @@ pub mod tests {
             assert_eq!(a.hash(&mut hasher), b.hash(&mut hasher));
         }
     }
+
+    #[test]
+    fn test_as_ref() {
+        let mut a: SmallVec<[u32; 2]> = SmallVec::new();
+        a.push(1);
+        assert_eq!(a.as_ref(), [1]);
+        a.push(2);
+        assert_eq!(a.as_ref(), [1, 2]);
+        a.push(3);
+        assert_eq!(a.as_ref(), [1, 2, 3]);
+    }
+
+    #[test]
+    fn test_as_mut() {
+        let mut a: SmallVec<[u32; 2]> = SmallVec::new();
+        a.push(1);
+        assert_eq!(a.as_mut(), [1]);
+        a.push(2);
+        assert_eq!(a.as_mut(), [1, 2]);
+        a.push(3);
+        assert_eq!(a.as_mut(), [1, 2, 3]);
+        a.as_mut()[1] = 4;
+        assert_eq!(a.as_mut(), [1, 4, 3]);
+    }
+
+    #[test]
+    fn test_borrow() {
+        use std::borrow::Borrow;
+
+        let mut a: SmallVec<[u32; 2]> = SmallVec::new();
+        a.push(1);
+        assert_eq!(a.borrow(), [1]);
+        a.push(2);
+        assert_eq!(a.borrow(), [1, 2]);
+        a.push(3);
+        assert_eq!(a.borrow(), [1, 2, 3]);
+    }
+
+    #[test]
+    fn test_borrow_mut() {
+        use std::borrow::BorrowMut;
+
+        let mut a: SmallVec<[u32; 2]> = SmallVec::new();
+        a.push(1);
+        assert_eq!(a.borrow_mut(), [1]);
+        a.push(2);
+        assert_eq!(a.borrow_mut(), [1, 2]);
+        a.push(3);
+        assert_eq!(a.borrow_mut(), [1, 2, 3]);
+        BorrowMut::<[u32]>::borrow_mut(&mut a)[1] = 4;
+        assert_eq!(a.borrow_mut(), [1, 4, 3]);
+    }
+
+    #[test]
+    fn test_from() {
+        assert_eq!(&SmallVec::<[u32; 2]>::from(&[1][..])[..], [1]);
+        assert_eq!(&SmallVec::<[u32; 2]>::from(&[1, 2, 3][..])[..], [1, 2, 3]);
+    }
+
+    #[test]
+    fn test_exact_size_iterator() {
+        let mut vec = SmallVec::<[u32; 2]>::from(&[1, 2, 3][..]);
+        assert_eq!(vec.clone().into_iter().len(), 3);
+        assert_eq!(vec.drain().len(), 3);
+    }
 }

--- a/lib.rs
+++ b/lib.rs
@@ -366,6 +366,13 @@ impl<A: Array> BorrowMut<[A::Item]> for SmallVec<A> {
     }
 }
 
+impl<'a, A: Array> From<&'a [A::Item]> for SmallVec<A> where A::Item: Clone {
+    #[inline]
+    fn from(slice: &'a [A::Item]) -> SmallVec<A> {
+        slice.into_iter().cloned().collect()
+    }
+}
+
 macro_rules! impl_index {
     ($index_type: ty, $output_type: ty) => {
         impl<A: Array> ops::Index<$index_type> for SmallVec<A> {

--- a/lib.rs
+++ b/lib.rs
@@ -71,6 +71,11 @@ impl<'a, T: 'a> Iterator for Drain<'a,T> {
             }
         }
     }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
 }
 
 impl<'a, T: 'a> DoubleEndedIterator for Drain<'a, T> {
@@ -86,6 +91,8 @@ impl<'a, T: 'a> DoubleEndedIterator for Drain<'a, T> {
         }
     }
 }
+
+impl<'a, T> ExactSizeIterator for Drain<'a, T> { }
 
 impl<'a, T: 'a> Drop for Drain<'a,T> {
     fn drop(&mut self) {
@@ -524,6 +531,12 @@ impl<A: Array> Iterator for IntoIter<A> {
             }
         }
     }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let size = self.end - self.current;
+        (size, Some(size))
+    }
 }
 
 impl<A: Array> DoubleEndedIterator for IntoIter<A> {
@@ -540,6 +553,8 @@ impl<A: Array> DoubleEndedIterator for IntoIter<A> {
         }
     }
 }
+
+impl<A: Array> ExactSizeIterator for IntoIter<A> { }
 
 impl<A: Array> IntoIterator for SmallVec<A> {
     type IntoIter = IntoIter<A>;

--- a/lib.rs
+++ b/lib.rs
@@ -525,7 +525,6 @@ impl<A: Array> Iterator for IntoIter<A> {
     type Item = A::Item;
     
     #[inline]
-    #[inline]
     fn next(&mut self) -> Option<A::Item> {
         if self.current == self.end {
             None    

--- a/lib.rs
+++ b/lib.rs
@@ -361,8 +361,8 @@ impl<A: Array> FromIterator<A::Item> for SmallVec<A> {
     }
 }
 
-impl<A: Array> SmallVec<A> {
-    pub fn extend<I: IntoIterator<Item=A::Item>>(&mut self, iterable: I) {
+impl<A: Array> Extend<A::Item> for SmallVec<A> {
+    fn extend<I: IntoIterator<Item=A::Item>>(&mut self, iterable: I) {
         let iter = iterable.into_iter();
         let (lower_size_bound, _) = iter.size_hint();
 


### PR DESCRIPTION
This PR implements almost all traits which [Vec](https://doc.rust-lang.org/std/vec/struct.Vec.html) implements for `SmallVec`, bringing it closer to being a drop in replacement for `Vec`. A few implementations were omitted such as `Extend<&A::Item>` which could not be implemented due to a conflict with `Extend<A::Item>`, a few `From` implementations which may be a bit more esoteric (easily added if so desired) and `Write`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-smallvec/26)
<!-- Reviewable:end -->
