### PR TITLE
Support std::iter::extend<T> for VecLike<T>

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -30,7 +30,8 @@ pub trait VecLike<T>:
         ops::Index<ops::RangeFull, Output=[T]> +
         ops::IndexMut<ops::RangeFull> +
         ops::Deref +
-        ops::DerefMut {
+        ops::DerefMut +
+        Extend<T> {
 
     fn len(&self) -> usize;
     fn push(&mut self, value: T);


### PR DESCRIPTION
VecLike naturally supports push, so it also makes sense to support extend. Both implementors SmallVec and Vec already have tested implementations, so this extension feels natural.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-smallvec/27)
<!-- Reviewable:end -->
