### PR TITLE
Implement extend_from_slice and insert_from_slice with memmove optimization

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -69,6 +69,18 @@ fn bench_extend_from_slice(b: &mut Bencher) {
     b.iter(|| {
         let mut vec: SmallVec<[u64; 16]> = SmallVec::new();
         vec.extend_from_slice(&v);
+        vec
+    });
+}
+
+#[bench]
+fn bench_insert_from_slice(b: &mut Bencher) {
+    let v: Vec<u64> = (0..100).collect();
+    b.iter(|| {
+        let mut vec: SmallVec<[u64; 16]> = SmallVec::new();
+        vec.insert_from_slice(0, &v);
+        vec.insert_from_slice(0, &v);
+        vec
     });
 }
 

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -64,6 +64,15 @@ fn bench_extend(b: &mut Bencher) {
 }
 
 #[bench]
+fn bench_extend_from_slice(b: &mut Bencher) {
+    let v: Vec<u64> = (0..100).collect();
+    b.iter(|| {
+        let mut vec: SmallVec<[u64; 16]> = SmallVec::new();
+        vec.extend_from_slice(&v);
+    });
+}
+
+#[bench]
 fn bench_pushpop(b: &mut Bencher) {
     #[inline(never)]
     fn pushpop_noinline(vec: &mut SmallVec<[u64; 16]>, x: u64) {

--- a/lib.rs
+++ b/lib.rs
@@ -477,6 +477,29 @@ impl<A: Array> SmallVec<A> {
     }
 }
 
+impl<A: Array> SmallVec<A> where A::Item: Copy {
+    pub fn insert_slice(&mut self, index: usize, slice: &[A::Item]) {
+        self.reserve(slice.len());
+
+        let len = self.len;
+        assert!(index <= len);
+
+        unsafe {
+            let slice_ptr = slice.as_ptr();
+            let ptr = self.as_mut_ptr().offset(index as isize);
+            ptr::copy(ptr, ptr.offset(slice.len() as isize), len - index);
+            ptr::copy(slice_ptr, ptr, slice.len());
+            self.set_len(len + slice.len());
+        }
+    }
+
+    #[inline]
+    pub fn extend_slice(&mut self, slice: &[A::Item]) {
+        let len = self.len();
+        self.insert_slice(len, slice);
+    }
+}
+
 impl<A: Array> ops::Deref for SmallVec<A> {
     type Target = [A::Item];
     #[inline]
@@ -1066,6 +1089,28 @@ pub mod tests {
         let mut v: SmallVec<[u8; 8]> = SmallVec::new();
         v.extend(0..8);
         v.grow(5);
+    }
+
+    #[test]
+    fn test_insert_slice() {
+        let mut v: SmallVec<[u8; 8]> = SmallVec::new();
+        for x in 0..4 {
+            v.push(x);
+        }
+        assert_eq!(v.len(), 4);
+        v.insert_slice(1, &[5, 6]);
+        assert_eq!(&v.iter().map(|v| *v).collect::<Vec<_>>(), &[0, 5, 6, 1, 2, 3]);
+    }
+
+    #[test]
+    fn test_extend_slice() {
+        let mut v: SmallVec<[u8; 8]> = SmallVec::new();
+        for x in 0..4 {
+            v.push(x);
+        }
+        assert_eq!(v.len(), 4);
+        v.extend_slice(&[5, 6]);
+        assert_eq!(&v.iter().map(|v| *v).collect::<Vec<_>>(), &[0, 1, 2, 3, 5, 6]);
     }
 
     #[test]

--- a/lib.rs
+++ b/lib.rs
@@ -478,7 +478,7 @@ impl<A: Array> SmallVec<A> {
 }
 
 impl<A: Array> SmallVec<A> where A::Item: Copy {
-    pub fn insert_slice(&mut self, index: usize, slice: &[A::Item]) {
+    pub fn insert_from_slice(&mut self, index: usize, slice: &[A::Item]) {
         self.reserve(slice.len());
 
         let len = self.len;
@@ -494,9 +494,9 @@ impl<A: Array> SmallVec<A> where A::Item: Copy {
     }
 
     #[inline]
-    pub fn extend_slice(&mut self, slice: &[A::Item]) {
+    pub fn extend_from_slice(&mut self, slice: &[A::Item]) {
         let len = self.len();
-        self.insert_slice(len, slice);
+        self.insert_from_slice(len, slice);
     }
 }
 
@@ -1092,24 +1092,24 @@ pub mod tests {
     }
 
     #[test]
-    fn test_insert_slice() {
+    fn test_insert_from_slice() {
         let mut v: SmallVec<[u8; 8]> = SmallVec::new();
         for x in 0..4 {
             v.push(x);
         }
         assert_eq!(v.len(), 4);
-        v.insert_slice(1, &[5, 6]);
+        v.insert_from_slice(1, &[5, 6]);
         assert_eq!(&v.iter().map(|v| *v).collect::<Vec<_>>(), &[0, 5, 6, 1, 2, 3]);
     }
 
     #[test]
-    fn test_extend_slice() {
+    fn test_extend_from_slice() {
         let mut v: SmallVec<[u8; 8]> = SmallVec::new();
         for x in 0..4 {
             v.push(x);
         }
         assert_eq!(v.len(), 4);
-        v.extend_slice(&[5, 6]);
+        v.extend_from_slice(&[5, 6]);
         assert_eq!(&v.iter().map(|v| *v).collect::<Vec<_>>(), &[0, 1, 2, 3, 5, 6]);
     }
 


### PR DESCRIPTION
Implement the performance optimized versions of insert_many and extend (from #28). These methods use memmove rather than a looped insert.

If we had function specialization, we could implement these without exposing new methods. Up to the maintainers whether we want to support these new methods.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-smallvec/29)

<!-- Reviewable:end -->
