### PR TITLE
Add benchmarks for push, insert, extend, and pushpop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,10 @@ rust:
   - nightly
   - beta
   - stable
+script: |
+  cargo build --verbose &&
+  cargo test --verbose &&
+  ([ $TRAVIS_RUST_VERSION != nightly ] || cargo test --verbose --features benchmarks) &&
+  ([ $TRAVIS_RUST_VERSION != nightly ] || cargo bench --verbose --features benchmarks bench)
 notifications:
   webhooks: http://build.servo.org:54856/travis

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,6 @@ documentation = "http://doc.servo.org/smallvec/"
 name = "smallvec"
 path = "lib.rs"
 doctest = false
+
+[features]
+benchmarks = []

--- a/lib.rs
+++ b/lib.rs
@@ -5,6 +5,8 @@
 //! Small vectors in various sizes. These store a certain number of elements inline and fall back
 //! to the heap for larger allocations.
 
+#![feature(test)]
+
 use std::borrow::{Borrow, BorrowMut};
 use std::cmp;
 use std::fmt;
@@ -647,8 +649,10 @@ impl_array!(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 20, 24, 32,
 
 #[cfg(test)]
 pub mod tests {
+    extern crate test;
     use SmallVec;
     use std::borrow::ToOwned;
+    use self::test::Bencher;
 
     // We heap allocate all these strings so that double frees will show up under valgrind.
 
@@ -999,5 +1003,44 @@ pub mod tests {
         let mut vec = SmallVec::<[u32; 2]>::from(&[1, 2, 3][..]);
         assert_eq!(vec.clone().into_iter().len(), 3);
         assert_eq!(vec.drain().len(), 3);
+    }
+
+    #[bench]
+    fn bench_push(b: &mut Bencher) {
+        b.iter(|| {
+            let mut vec: SmallVec<[u64; 16]> = SmallVec::new();
+            for x in 0..100 {
+                vec.push(x);
+            }
+        });
+    }
+
+    #[bench]
+    fn bench_insert(b: &mut Bencher) {
+        b.iter(|| {
+            let mut vec: SmallVec<[u64; 16]> = SmallVec::new();
+            for x in 0..100 {
+                vec.insert(0, x);
+            }
+        });
+    }
+
+    #[bench]
+    fn bench_extend(b: &mut Bencher) {
+        b.iter(|| {
+            let mut vec: SmallVec<[u64; 16]> = SmallVec::new();
+            vec.extend(0..100);
+        });
+    }
+
+    #[bench]
+    fn bench_pushpop(b: &mut Bencher) {
+        b.iter(|| {
+            let mut vec: SmallVec<[u64; 16]> = SmallVec::new();
+            for x in 0..100 {
+                vec.push(x);
+                vec.pop();
+            }
+        });
     }
 }

--- a/lib.rs
+++ b/lib.rs
@@ -5,7 +5,7 @@
 //! Small vectors in various sizes. These store a certain number of elements inline and fall back
 //! to the heap for larger allocations.
 
-#![feature(test)]
+#![cfg_attr(feature = "benchmarks", feature(test))]
 
 use std::borrow::{Borrow, BorrowMut};
 use std::cmp;
@@ -649,10 +649,8 @@ impl_array!(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 20, 24, 32,
 
 #[cfg(test)]
 pub mod tests {
-    extern crate test;
     use SmallVec;
     use std::borrow::ToOwned;
-    use self::test::Bencher;
 
     // We heap allocate all these strings so that double frees will show up under valgrind.
 
@@ -1004,6 +1002,13 @@ pub mod tests {
         assert_eq!(vec.clone().into_iter().len(), 3);
         assert_eq!(vec.drain().len(), 3);
     }
+}
+
+#[cfg(all(feature = "benchmarks", test))]
+mod bench {
+    extern crate test;
+    use SmallVec;
+    use self::test::Bencher;
 
     #[bench]
     fn bench_push(b: &mut Bencher) {
@@ -1012,6 +1017,7 @@ pub mod tests {
             for x in 0..100 {
                 vec.push(x);
             }
+            vec
         });
     }
 
@@ -1022,6 +1028,7 @@ pub mod tests {
             for x in 0..100 {
                 vec.insert(0, x);
             }
+            vec
         });
     }
 
@@ -1030,6 +1037,7 @@ pub mod tests {
         b.iter(|| {
             let mut vec: SmallVec<[u64; 16]> = SmallVec::new();
             vec.extend(0..100);
+            vec
         });
     }
 
@@ -1041,6 +1049,7 @@ pub mod tests {
                 vec.push(x);
                 vec.pop();
             }
+            vec
         });
     }
 }


### PR DESCRIPTION
Want to add these benchmarks so that we can more effectively detect regressions/improvements from PR's like #28 and #29.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-smallvec/31)
<!-- Reviewable:end -->
