### PR TITLE
Move benchmarks to benches module with noinline wrappers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ rust:
 script: |
   cargo build --verbose &&
   cargo test --verbose &&
-  ([ $TRAVIS_RUST_VERSION != nightly ] || cargo test --verbose --features benchmarks) &&
-  ([ $TRAVIS_RUST_VERSION != nightly ] || cargo bench --verbose --features benchmarks bench)
+  ([ $TRAVIS_RUST_VERSION != nightly ] || cargo bench --verbose bench)
 notifications:
   webhooks: http://build.servo.org:54856/travis

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,3 @@ documentation = "http://doc.servo.org/smallvec/"
 name = "smallvec"
 path = "lib.rs"
 doctest = false
-
-[features]
-benchmarks = []

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -8,10 +8,15 @@ use self::test::Bencher;
 
 #[bench]
 fn bench_push(b: &mut Bencher) {
+    #[inline(never)]
+    fn push_noinline(vec: &mut SmallVec<[u64; 16]>, x: u64) {
+        vec.push(x)
+    }
+
     b.iter(|| {
         let mut vec: SmallVec<[u64; 16]> = SmallVec::new();
         for x in 0..100 {
-            vec.push(x);
+            push_noinline(&mut vec, x);
         }
         vec
     });
@@ -19,10 +24,15 @@ fn bench_push(b: &mut Bencher) {
 
 #[bench]
 fn bench_insert(b: &mut Bencher) {
+    #[inline(never)]
+    fn insert_noinline(vec: &mut SmallVec<[u64; 16]>, x: u64) {
+        vec.insert(0, x)
+    }
+
     b.iter(|| {
         let mut vec: SmallVec<[u64; 16]> = SmallVec::new();
         for x in 0..100 {
-            vec.insert(0, x);
+            insert_noinline(&mut vec, x);
         }
         vec
     });
@@ -39,11 +49,16 @@ fn bench_extend(b: &mut Bencher) {
 
 #[bench]
 fn bench_pushpop(b: &mut Bencher) {
+    #[inline(never)]
+    fn pushpop_noinline(vec: &mut SmallVec<[u64; 16]>, x: u64) {
+        vec.push(x);
+        vec.pop();
+    }
+
     b.iter(|| {
         let mut vec: SmallVec<[u64; 16]> = SmallVec::new();
         for x in 0..100 {
-            vec.push(x);
-            vec.pop();
+            pushpop_noinline(&mut vec, x);
         }
         vec
     });

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,0 +1,50 @@
+#![feature(test)]
+
+extern crate smallvec;
+extern crate test;
+
+use smallvec::SmallVec;
+use self::test::Bencher;
+
+#[bench]
+fn bench_push(b: &mut Bencher) {
+    b.iter(|| {
+        let mut vec: SmallVec<[u64; 16]> = SmallVec::new();
+        for x in 0..100 {
+            vec.push(x);
+        }
+        vec
+    });
+}
+
+#[bench]
+fn bench_insert(b: &mut Bencher) {
+    b.iter(|| {
+        let mut vec: SmallVec<[u64; 16]> = SmallVec::new();
+        for x in 0..100 {
+            vec.insert(0, x);
+        }
+        vec
+    });
+}
+
+#[bench]
+fn bench_extend(b: &mut Bencher) {
+    b.iter(|| {
+        let mut vec: SmallVec<[u64; 16]> = SmallVec::new();
+        vec.extend(0..100);
+        vec
+    });
+}
+
+#[bench]
+fn bench_pushpop(b: &mut Bencher) {
+    b.iter(|| {
+        let mut vec: SmallVec<[u64; 16]> = SmallVec::new();
+        for x in 0..100 {
+            vec.push(x);
+            vec.pop();
+        }
+        vec
+    });
+}

--- a/lib.rs
+++ b/lib.rs
@@ -5,8 +5,6 @@
 //! Small vectors in various sizes. These store a certain number of elements inline and fall back
 //! to the heap for larger allocations.
 
-#![cfg_attr(feature = "benchmarks", feature(test))]
-
 use std::borrow::{Borrow, BorrowMut};
 use std::cmp;
 use std::fmt;
@@ -1008,55 +1006,5 @@ pub mod tests {
         let mut vec = SmallVec::<[u32; 2]>::from(&[1, 2, 3][..]);
         assert_eq!(vec.clone().into_iter().len(), 3);
         assert_eq!(vec.drain().len(), 3);
-    }
-}
-
-#[cfg(all(feature = "benchmarks", test))]
-mod bench {
-    extern crate test;
-    use SmallVec;
-    use self::test::Bencher;
-
-    #[bench]
-    fn bench_push(b: &mut Bencher) {
-        b.iter(|| {
-            let mut vec: SmallVec<[u64; 16]> = SmallVec::new();
-            for x in 0..100 {
-                vec.push(x);
-            }
-            vec
-        });
-    }
-
-    #[bench]
-    fn bench_insert(b: &mut Bencher) {
-        b.iter(|| {
-            let mut vec: SmallVec<[u64; 16]> = SmallVec::new();
-            for x in 0..100 {
-                vec.insert(0, x);
-            }
-            vec
-        });
-    }
-
-    #[bench]
-    fn bench_extend(b: &mut Bencher) {
-        b.iter(|| {
-            let mut vec: SmallVec<[u64; 16]> = SmallVec::new();
-            vec.extend(0..100);
-            vec
-        });
-    }
-
-    #[bench]
-    fn bench_pushpop(b: &mut Bencher) {
-        b.iter(|| {
-            let mut vec: SmallVec<[u64; 16]> = SmallVec::new();
-            for x in 0..100 {
-                vec.push(x);
-                vec.pop();
-            }
-            vec
-        });
     }
 }


### PR DESCRIPTION
This ensures that the benchmarks are in a separate crate and linked
against the smallvec dynamic library rather than being compiled
together.

It also nicely removes the need for the "benchmarks" feature.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-smallvec/32)
<!-- Reviewable:end -->
