### PR TITLE
Specify that VecLike derefs to a slice

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smallvec"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Simon Sapin <simon.sapin@exyr.org>"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/rust-smallvec"


### PR DESCRIPTION
I believe this is just an oversight. Since `<[T]>::len` is now available through the `Deref` bound I also removed `VecLike::len`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-smallvec/38)
<!-- Reviewable:end -->
