### PR TITLE
Add HeapSizeOf trait and from_slice method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@ rust:
   - stable
 script: |
   cargo build --verbose &&
+  cargo build --features=heapsizeof --verbose &&
   cargo test --verbose &&
+  cargo test --features=heapsizeof --verbose &&
   ([ $TRAVIS_RUST_VERSION != nightly ] || cargo bench --verbose bench)
 notifications:
   webhooks: http://build.servo.org:54856/travis

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,6 @@ documentation = "http://doc.servo.org/smallvec/"
 [lib]
 name = "smallvec"
 path = "lib.rs"
+
+[dependencies]
+heapsize =  "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,12 @@ keywords = ["small", "vec", "vector", "stack"]
 readme = "README.md"
 documentation = "http://doc.servo.org/smallvec/"
 
+[features]
+heapsizeof = ["heapsize"]
+
 [lib]
 name = "smallvec"
 path = "lib.rs"
 
 [dependencies]
-heapsize =  "0.3"
+heapsize = { version = "0.3", optional = true }

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -64,6 +64,15 @@ fn bench_extend(b: &mut Bencher) {
 }
 
 #[bench]
+fn bench_from_slice(b: &mut Bencher) {
+    let v: Vec<u64> = (0..100).collect();
+    b.iter(|| {
+        let vec: SmallVec<[u64; 16]> = SmallVec::from_slice(&v);
+        vec
+    });
+}
+
+#[bench]
 fn bench_extend_from_slice(b: &mut Bencher) {
     let v: Vec<u64> = (0..100).collect();
     b.iter(|| {

--- a/lib.rs
+++ b/lib.rs
@@ -6,6 +6,9 @@
 //! to the heap for larger allocations.  This can be a useful optimization for improving cache
 //! locality and reducing allocator traffic for workloads that fit within the inline buffer.
 
+#![feature(specialization)]
+
+#[cfg(feature="heapsizeof")]
 extern crate heapsize;
 
 use std::borrow::{Borrow, BorrowMut};
@@ -14,11 +17,13 @@ use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::iter::{IntoIterator, FromIterator};
 use std::mem;
-use std::os::raw::c_void;
 use std::ops;
 use std::ptr;
 use std::slice;
+#[cfg(feature="heapsizeof")]
+use std::os::raw::c_void;
 
+#[cfg(feature="heapsizeof")]
 use heapsize::{HeapSizeOf, heap_size_of};
 use SmallVecData::{Inline, Heap};
 
@@ -510,6 +515,7 @@ impl<A: Array> SmallVec<A> where A::Item: Copy {
     }
 }
 
+#[cfg(feature="heapsizeof")]
 impl<A: Array> HeapSizeOf for SmallVec<A> where A::Item: HeapSizeOf {
     fn heap_size_of_children(&self) -> usize {
         match self.data {
@@ -853,9 +859,12 @@ impl_array!(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 20, 24, 32, 3
 #[cfg(test)]
 pub mod tests {
     use SmallVec;
-    use heapsize::HeapSizeOf;
     use std::borrow::ToOwned;
     use std::iter::FromIterator;
+
+    #[cfg(feature="heapsizeof")]
+    use heapsize::HeapSizeOf;
+    #[cfg(feature="heapsizeof")]
     use std::mem::size_of;
 
     // We heap allocate all these strings so that double frees will show up under valgrind.
@@ -1279,6 +1288,7 @@ pub mod tests {
         assert_eq!(&SmallVec::<[u32; 2]>::from_slice(&[1, 2, 3][..])[..], [1, 2, 3]);
     }
 
+    #[cfg(feature="heapsizeof")]
     #[test]
     fn test_heap_size_of_children() {
         let mut vec = SmallVec::<[u32; 2]>::new();

--- a/lib.rs
+++ b/lib.rs
@@ -6,8 +6,6 @@
 //! to the heap for larger allocations.  This can be a useful optimization for improving cache
 //! locality and reducing allocator traffic for workloads that fit within the inline buffer.
 
-#![feature(specialization)]
-
 #[cfg(feature="heapsizeof")]
 extern crate heapsize;
 


### PR DESCRIPTION
Also added some tests for the new methods. The rationale
- from_slice is an ergonomic way to convert a Copy-able slice to a SmallVec (instead of using the From<'a slice> which uses an iterator)
- HeapSizeOf is handy for measuring heap allocations. Especially useful for monitoring something like this. Seems to be part of the servo project anyway.
- Added size 36 to smallvec sizes (was useful to us)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-smallvec/42)
<!-- Reviewable:end -->
