### PR TITLE
Don't zero the array on initialization

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -202,7 +202,7 @@ impl<A: Array> SmallVec<A> {
         unsafe {
             SmallVec {
                 len: 0,
-                data: Inline { array: mem::zeroed() },
+                data: Inline { array: mem::uninitialized() },
             }
         }
     }


### PR DESCRIPTION
Using `mem::uninitialized` is potentially faster than `mem::zeroed`, and doesn't remove any safety (since both uninitialized memory and zeroed memory are unsafe to read from in general).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-smallvec/43)
<!-- Reviewable:end -->
