### PR TITLE
Add SmallVec::into_vec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smallvec"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Simon Sapin <simon.sapin@exyr.org>"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/rust-smallvec"


### PR DESCRIPTION
Converts a SmallVec to a Vec, without reallocating if the SmallVec has already spilled onto the heap.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-smallvec/45)
<!-- Reviewable:end -->
