### PR TITLE
Re-enable cargo bench on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ script: |
   cargo build --verbose &&
   cargo build --features=heapsizeof --verbose &&
   cargo test --verbose &&
-  cargo test --features=heapsizeof --verbose
+  cargo test --features=heapsizeof --verbose &&
+  ([ $TRAVIS_RUST_VERSION != nightly ] || cargo bench --verbose bench)
 notifications:
   webhooks: http://build.servo.org:54856/travis


### PR DESCRIPTION
This reverts commit 0586430085763b35b491fe975761270a23602834 which disabled `cargo bench` on Travis because of #44  which is now fixed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-smallvec/47)
<!-- Reviewable:end -->
