### PR TITLE
Add no_std support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,10 @@ readme = "README.md"
 documentation = "http://doc.servo.org/smallvec/"
 
 [features]
-heapsizeof = ["heapsize"]
+heapsizeof = ["heapsize", "std"]
+collections = []
+std = []
+default = ["std"]
 
 [lib]
 name = "smallvec"

--- a/lib.rs
+++ b/lib.rs
@@ -6,8 +6,23 @@
 //! to the heap for larger allocations.  This can be a useful optimization for improving cache
 //! locality and reducing allocator traffic for workloads that fit within the inline buffer.
 
+#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(feature = "std"), feature(collections))]
+
+
+#[cfg(not(feature = "std"))]
+extern crate collections;
+
+#[cfg(not(feature = "std"))]
+use collections::Vec;
+
 #[cfg(feature="heapsizeof")]
 extern crate heapsize;
+
+#[cfg(not(feature = "std"))]
+mod std {
+    pub use core::*;
+}
 
 use std::borrow::{Borrow, BorrowMut};
 use std::cmp;


### PR DESCRIPTION
This library can easily support `no_std` code on `nightly`; it does require the `collections` feature, however. This PR adds support for this feature by enabling a on-by-default `std` feature. This feature can be turned off to support `no_std` mode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-smallvec/49)
<!-- Reviewable:end -->
