### PR TITLE
Document and test no_std support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ script: |
   cargo build --features=heapsizeof --verbose &&
   cargo test --verbose &&
   cargo test --features=heapsizeof --verbose &&
+  ([ $TRAVIS_RUST_VERSION != nightly ] || cargo test --verbose --no-default-features) &&
   ([ $TRAVIS_RUST_VERSION != nightly ] || cargo bench --verbose bench)
 notifications:
   webhooks: http://build.servo.org:54856/travis

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smallvec"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Simon Sapin <simon.sapin@exyr.org>"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/rust-smallvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ documentation = "http://doc.servo.org/smallvec/"
 
 [features]
 heapsizeof = ["heapsize", "std"]
-collections = []
 std = []
 default = ["std"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Simon Sapin <simon.sapin@exyr.org>"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/rust-smallvec"
 description = "'Small vector' optimization: store up to a small number of items on the stack"
-keywords = ["small", "vec", "vector", "stack"]
+keywords = ["small", "vec", "vector", "stack", "no_std"]
 readme = "README.md"
 documentation = "http://doc.servo.org/smallvec/"
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 rust-smallvec
 =============
 
-[Documentation](http://doc.servo.org/smallvec/)
+[Documentation](http://docs.rs/smallvec/)
 
 "Small vector" optimization for Rust: store up to a small number of items on the stack

--- a/lib.rs
+++ b/lib.rs
@@ -5,6 +5,15 @@
 //! Small vectors in various sizes. These store a certain number of elements inline, and fall back
 //! to the heap for larger allocations.  This can be a useful optimization for improving cache
 //! locality and reducing allocator traffic for workloads that fit within the inline buffer.
+//!
+//! ## no_std support
+//!
+//! By default, `smallvec` depends on `libstd`. However, it can be configured to use the unstable
+//! `liballoc` API instead, for use on platforms that have `liballoc` but not `libstd`.  This
+//! configuration is currently unstable and is not guaranteed to work on all versions of Rust.
+//!
+//! To depend on `smallvec` without `libstd`, use `default-features = false` in the `smallvec`
+//! section of Cargo.toml to disable its `"std"` feature.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(not(feature = "std"), feature(alloc))]

--- a/lib.rs
+++ b/lib.rs
@@ -11,6 +11,7 @@
 
 
 #[cfg(not(feature = "std"))]
+#[cfg_attr(test, macro_use)]
 extern crate alloc;
 
 #[cfg(not(feature = "std"))]
@@ -967,8 +968,17 @@ impl_array!(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 20, 24, 32, 3
 #[cfg(test)]
 pub mod tests {
     use SmallVec;
-    use std::borrow::ToOwned;
+
     use std::iter::FromIterator;
+
+    #[cfg(feature = "std")]
+    use std::borrow::ToOwned;
+    #[cfg(not(feature = "std"))]
+    use alloc::borrow::ToOwned;
+    #[cfg(not(feature = "std"))]
+    use alloc::boxed::Box;
+    #[cfg(not(feature = "std"))]
+    use alloc::vec::Vec;
 
     #[cfg(feature="heapsizeof")]
     use heapsize::HeapSizeOf;
@@ -1311,6 +1321,7 @@ pub mod tests {
         assert!(c > b);
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn test_hash() {
         use std::hash::Hash;

--- a/lib.rs
+++ b/lib.rs
@@ -7,14 +7,14 @@
 //! locality and reducing allocator traffic for workloads that fit within the inline buffer.
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(not(feature = "std"), feature(collections))]
+#![cfg_attr(not(feature = "std"), feature(alloc))]
 
 
 #[cfg(not(feature = "std"))]
-extern crate collections;
+extern crate alloc;
 
 #[cfg(not(feature = "std"))]
-use collections::Vec;
+use alloc::Vec;
 
 #[cfg(feature="heapsizeof")]
 extern crate heapsize;


### PR DESCRIPTION
This builds on the new "std" Cargo feature added in #49.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-smallvec/53)
<!-- Reviewable:end -->
