### PR TITLE
Add from_buf method

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -289,6 +289,25 @@ impl<A: Array> SmallVec<A> {
         }
     }
 
+    /// Constructs a new `SmallVec` on the stack from an `A` without
+    /// copying elements.
+    ///
+    /// ```rust
+    /// use smallvec::SmallVec;
+    ///
+    /// let buf = [1, 2, 3, 4, 5];
+    /// let small_vec: SmallVec<_> = SmallVec::from_buf(buf);
+    ///
+    /// assert_eq!(&*small_vec, &[1, 2, 3, 4, 5]);
+    /// ```
+    #[inline]
+    pub fn from_buf(buf: A) -> SmallVec<A> {
+        SmallVec {
+            len: A::size(),
+            data: SmallVecData::Inline { array: buf },
+        }
+    }
+
     /// Sets the length of a vector.
     ///
     /// This will explicitly set the size of the vector, without actually


### PR DESCRIPTION
If you have an `A` on the stack already this allows you to create a `SmallVec<A>` with zero copying.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-smallvec/56)
<!-- Reviewable:end -->
