### PR TITLE
Release version 0.4.2.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smallvec"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Simon Sapin <simon.sapin@exyr.org>"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/rust-smallvec"


### PR DESCRIPTION
* Add `SmallVec::from_buf` constructor (#56).
* Add optional `serde` (de-)serialization support (#57).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-smallvec/58)
<!-- Reviewable:end -->
