### PR TITLE
Publish new version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smallvec"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["Simon Sapin <simon.sapin@exyr.org>"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/rust-smallvec"


### PR DESCRIPTION
It would be helpful to me to put the new `retain()` function on cargo.  Do you mind publishing a new minor version?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-smallvec/60)
<!-- Reviewable:end -->
