### PR TITLE
Simplify unsafe pointer code in SmallVec::pop

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -412,8 +412,8 @@ impl<A: Array> SmallVec<A> {
             panic!("overflow")
         }
         unsafe {
-            let end_ptr = self.as_mut_ptr().offset(last_index as isize);
-            let value = ptr::replace(end_ptr, mem::uninitialized());
+            let end_ptr = self.as_ptr().offset(last_index as isize);
+            let value = ptr::read(end_ptr);
             self.set_len(last_index);
             Some(value)
         }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-smallvec/64)
<!-- Reviewable:end -->
