### PR TITLE
Remove `heapsize` dependency.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smallvec"
-version = "0.4.4"
+version = "0.5.0"
 authors = ["Simon Sapin <simon.sapin@exyr.org>"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/rust-smallvec"
@@ -10,7 +10,6 @@ readme = "README.md"
 documentation = "http://doc.servo.org/smallvec/"
 
 [features]
-heapsizeof = ["heapsize", "std"]
 std = []
 default = ["std"]
 
@@ -19,7 +18,6 @@ name = "smallvec"
 path = "lib.rs"
 
 [dependencies]
-heapsize = { version = "0.4", optional = true }
 serde = { version = "1", optional = true }
 
 [dev_dependencies]


### PR DESCRIPTION
The heapsize crate is being deprecated in favour of the malloc_size_of
crate within Servo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-smallvec/68)
<!-- Reviewable:end -->
