### PR TITLE
Use copy_nonoverlapping in insert_from_slice

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -669,7 +669,7 @@ impl<A: Array> SmallVec<A> where A::Item: Copy {
             let slice_ptr = slice.as_ptr();
             let ptr = self.as_mut_ptr().offset(index as isize);
             ptr::copy(ptr, ptr.offset(slice.len() as isize), len - index);
-            ptr::copy(slice_ptr, ptr, slice.len());
+            ptr::copy_nonoverlapping(slice_ptr, ptr, slice.len());
             self.set_len(len + slice.len());
         }
     }


### PR DESCRIPTION
Since this method takes a unique reference to `self`, we know that it can't overlap with `slice`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-smallvec/76)
<!-- Reviewable:end -->
