### PR TITLE
Version 0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "smallvec"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Simon Sapin <simon.sapin@exyr.org>"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/rust-smallvec"
 description = "'Small vector' optimization: store up to a small number of items on the stack"
 keywords = ["small", "vec", "vector", "stack", "no_std"]
+categories = ["data-structures"]
 readme = "README.md"
 documentation = "http://doc.servo.org/smallvec/"
 

--- a/README.md
+++ b/README.md
@@ -3,4 +3,6 @@ rust-smallvec
 
 [Documentation](http://docs.rs/smallvec/)
 
+[Release notes](https://github.com/servo/rust-smallvec/releases)
+
 "Small vector" optimization for Rust: store up to a small number of items on the stack


### PR DESCRIPTION
Includes these changes since the last release:

* Breaking change: Remove deprecated `SmallVecN` type aliases and `push_all_move` method (#77)
* Breaking change: Make `retain` pass `&mut T` to its predicate (#61)
* Add new methods `dedup`, `dedup_by`, and `dedup_by_key` (#72)
* Deprecate the `VecLike` trait in favor of standard library traits (#74)
* Optimize the `Clone` and `Deserialize` implementations to avoid unnecessary reallocation (#71)
* Optimize `extend_from_slice` and `insert_from_slice` to use `copy_nonoverlapping` (#76)
* Include the text of the Mozilla Public License in the source repo (#69)
* Improved documentation (#75)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-smallvec/78)
<!-- Reviewable:end -->
