### PR TITLE
Make SmallVec::retain compatible with Vec::remain

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -634,11 +634,11 @@ impl<A: Array> SmallVec<A> {
     /// In other words, remove all elements `e` such that `f(&e)` returns `false`.
     /// This method operates in place and preserves the order of the retained
     /// elements.
-    pub fn retain<F: FnMut(&mut A::Item) -> bool>(&mut self, mut f: F) {
+    pub fn retain<F: FnMut(&A::Item) -> bool>(&mut self, mut f: F) {
         let mut del = 0;
         let len = self.len;
         for i in 0..len {
-            if !f(&mut self[i]) {
+            if !f(&self[i]) {
                 del += 1;
             } else if del > 0 {
                 self.swap(i - del, i);
@@ -1710,7 +1710,7 @@ mod tests {
     fn test_retain() {
         // Test inline data storate
         let mut sv: SmallVec<[i32; 5]> = SmallVec::from_slice(&[1, 2, 3, 3, 4]);
-        sv.retain(|&mut i| i != 3);
+        sv.retain(|&i| i != 3);
         assert_eq!(sv.pop(), Some(4));
         assert_eq!(sv.pop(), Some(2));
         assert_eq!(sv.pop(), Some(1));
@@ -1718,7 +1718,7 @@ mod tests {
 
         // Test spilled data storage
         let mut sv: SmallVec<[i32; 3]> = SmallVec::from_slice(&[1, 2, 3, 3, 4]);
-        sv.retain(|&mut i| i != 3);
+        sv.retain(|&i| i != 3);
         assert_eq!(sv.pop(), Some(4));
         assert_eq!(sv.pop(), Some(2));
         assert_eq!(sv.pop(), Some(1));


### PR DESCRIPTION
Replaces `&mut` with `&` in the function predicate so that it's compatible with `Vec::retain`:

```rust
pub fn retain<F>(&mut self, f: F) 
where
    F: FnMut(&T) -> bool
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-smallvec/89)
<!-- Reviewable:end -->
