### PR TITLE
 Add vec!-like smallvec! macro

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,5 +1,6 @@
 #![feature(test)]
 
+#[macro_use]
 extern crate smallvec;
 extern crate test;
 
@@ -106,6 +107,26 @@ fn bench_pushpop(b: &mut Bencher) {
         for x in 0..100 {
             pushpop_noinline(&mut vec, x);
         }
+        vec
+    });
+}
+
+#[bench]
+fn bench_macro_from_elem(b: &mut Bencher) {
+    b.iter(|| {
+        let vec: SmallVec<[u64; 16]> = smallvec![42; 100];
+        vec
+    });
+}
+
+#[bench]
+fn bench_macro_from_list(b: &mut Bencher) {
+    b.iter(|| {
+        let vec: SmallVec<[u64; 16]> = smallvec![
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 20, 24, 32, 36, 0x40, 0x80,
+            0x100, 0x200, 0x400, 0x800, 0x1000, 0x2000, 0x4000, 0x8000, 0x10000, 0x20000, 0x40000,
+            0x80000, 0x100000
+        ];
         vec
     });
 }

--- a/lib.rs
+++ b/lib.rs
@@ -55,6 +55,55 @@ use std::marker::PhantomData;
 
 use SmallVecData::{Inline, Heap};
 
+/// Creates a [`SmallVec`] containing the arguments.
+///
+/// `smallvec!` allows `SmallVec`s to be defined with the same syntax as array expressions.
+/// There are two forms of this macro:
+///
+/// - Create a [`SmallVec`] containing a given list of elements:
+///
+/// ```
+/// # #[macro_use] extern crate smallvec;
+/// # use smallvec::SmallVec;
+/// # fn main() {
+/// let v: SmallVec<[_; 128]> = smallvec![1, 2, 3];
+/// assert_eq!(v[0], 1);
+/// assert_eq!(v[1], 2);
+/// assert_eq!(v[2], 3);
+/// # }
+/// ```
+///
+/// - Create a [`SmallVec`] from a given element and size:
+///
+/// ```
+/// # #[macro_use] extern crate smallvec;
+/// # use smallvec::SmallVec;
+/// # fn main() {
+/// let v: SmallVec<[_; 0x8000]> = smallvec![1; 3];
+/// assert_eq!(v, SmallVec::from_buf([1, 1, 1]));
+/// # }
+/// ```
+///
+/// Note that unlike array expressions this syntax supports all elements
+/// which implement [`Clone`] and the number of elements doesn't have to be
+/// a constant.
+///
+/// This will use `clone` to duplicate an expression, so one should be careful
+/// using this with types having a nonstandard `Clone` implementation. For
+/// example, `smallvec![Rc::new(1); 5]` will create a vector of five references
+/// to the same boxed integer value, not five references pointing to independently
+/// boxed integers.
+
+#[macro_export]
+macro_rules! smallvec {
+    ($elem:expr; $n:expr) => ({
+        SmallVec::from_elem($elem, $n)
+    });
+    ($($x:expr),*) => ({
+        SmallVec::from_slice(&[$($x),*])
+    });
+}
+
 /// Common operations implemented by both `Vec` and `SmallVec`.
 ///
 /// This can be used to write generic code that works with both `Vec` and `SmallVec`.

--- a/lib.rs
+++ b/lib.rs
@@ -747,6 +747,19 @@ impl<A: Array> SmallVec<A> where A::Item: Clone {
             self.truncate(len);
         }
     }
+
+    /// Creates a `SmallVec` with `n` copies of `elem`.
+    /// ```
+    /// use smallvec::SmallVec;
+    /// 
+    /// let v = SmallVec::<[char; 128]>::from_elem('d', 2);
+    /// assert_eq!(v, SmallVec::from_buf(['d', 'd']));
+    /// ```
+    pub fn from_elem(elem: A::Item, n: usize) -> Self {
+        let mut v = SmallVec::with_capacity(n);
+        v.insert_many(0, (0..n).map(|_| elem.clone()));
+        v
+    }
 }
 
 impl<A: Array> ops::Deref for SmallVec<A> {


### PR DESCRIPTION
Hello,

This implements a smallvec! macro for the smallvec package. It infers the underlying Array size and has similar syntax to `vec!`. For users wishing to incorporate smallvec into their projects, this macro eases the transition significantly.

Thanks for considering.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-smallvec/90)
<!-- Reviewable:end -->
