### PR TITLE
[WIP] Use a union to reduce the size of SmallVec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,9 @@ rust:
   - stable
 script: |
   cargo build --verbose &&
-  cargo build --all-features --verbose &&
   cargo test --verbose &&
-  cargo test --all-features --verbose &&
   ([ $TRAVIS_RUST_VERSION != nightly ] || cargo test --verbose --no-default-features) &&
+  ([ $TRAVIS_RUST_VERSION != nightly ] || cargo test --verbose --features union) &&
   ([ $TRAVIS_RUST_VERSION != nightly ] || cargo bench --verbose bench)
 notifications:
   webhooks: http://build.servo.org:54856/travis

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ documentation = "http://doc.servo.org/smallvec/"
 
 [features]
 std = []
+union = []
 default = ["std"]
 
 [lib]

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -4,8 +4,8 @@
 extern crate smallvec;
 extern crate test;
 
-use smallvec::SmallVec;
 use self::test::Bencher;
+use smallvec::SmallVec;
 
 #[bench]
 fn bench_push(b: &mut Bencher) {
@@ -42,8 +42,11 @@ fn bench_insert(b: &mut Bencher) {
 #[bench]
 fn bench_insert_many(b: &mut Bencher) {
     #[inline(never)]
-    fn insert_many_noinline<I: IntoIterator<Item=u64>>(
-        vec: &mut SmallVec<[u64; 16]>, index: usize, iterable: I) {
+    fn insert_many_noinline<I: IntoIterator<Item = u64>>(
+        vec: &mut SmallVec<[u64; 16]>,
+        index: usize,
+        iterable: I,
+    ) {
         vec.insert_many(index, iterable)
     }
 

--- a/lib.rs
+++ b/lib.rs
@@ -19,7 +19,6 @@
 #![cfg_attr(not(feature = "std"), feature(alloc))]
 #![deny(missing_docs)]
 
-
 #[cfg(not(feature = "std"))]
 #[cfg_attr(test, macro_use)]
 extern crate alloc;
@@ -35,25 +34,25 @@ mod std {
     pub use core::*;
 }
 
+#[cfg(feature = "serde")]
+use serde::de::{Deserialize, Deserializer, SeqAccess, Visitor};
+#[cfg(feature = "serde")]
+use serde::ser::{Serialize, SerializeSeq, Serializer};
 use std::borrow::{Borrow, BorrowMut};
 use std::cmp;
 use std::fmt;
 use std::hash::{Hash, Hasher};
-use std::iter::{IntoIterator, FromIterator, repeat};
+#[cfg(feature = "std")]
+use std::io;
+use std::iter::{repeat, FromIterator, IntoIterator};
+#[cfg(feature = "serde")]
+use std::marker::PhantomData;
 use std::mem;
 use std::ops;
 use std::ptr;
 use std::slice;
-#[cfg(feature = "std")]
-use std::io;
-#[cfg(feature = "serde")]
-use serde::ser::{Serialize, Serializer, SerializeSeq};
-#[cfg(feature = "serde")]
-use serde::de::{Deserialize, Deserializer, SeqAccess, Visitor};
-#[cfg(feature = "serde")]
-use std::marker::PhantomData;
 
-use SmallVecData::{Inline, Heap};
+use SmallVecData::{Heap, Inline};
 
 /// Creates a [`SmallVec`] containing the arguments.
 ///
@@ -127,19 +126,19 @@ macro_rules! smallvec {
 /// ```
 #[deprecated(note = "Use `Extend` and `Deref<[T]>` instead")]
 pub trait VecLike<T>:
-        ops::Index<usize, Output=T> +
-        ops::IndexMut<usize> +
-        ops::Index<ops::Range<usize>, Output=[T]> +
-        ops::IndexMut<ops::Range<usize>> +
-        ops::Index<ops::RangeFrom<usize>, Output=[T]> +
-        ops::IndexMut<ops::RangeFrom<usize>> +
-        ops::Index<ops::RangeTo<usize>, Output=[T]> +
-        ops::IndexMut<ops::RangeTo<usize>> +
-        ops::Index<ops::RangeFull, Output=[T]> +
-        ops::IndexMut<ops::RangeFull> +
-        ops::DerefMut<Target = [T]> +
-        Extend<T> {
-
+    ops::Index<usize, Output = T>
+    + ops::IndexMut<usize>
+    + ops::Index<ops::Range<usize>, Output = [T]>
+    + ops::IndexMut<ops::Range<usize>>
+    + ops::Index<ops::RangeFrom<usize>, Output = [T]>
+    + ops::IndexMut<ops::RangeFrom<usize>>
+    + ops::Index<ops::RangeTo<usize>, Output = [T]>
+    + ops::IndexMut<ops::RangeTo<usize>>
+    + ops::Index<ops::RangeFull, Output = [T]>
+    + ops::IndexMut<ops::RangeFull>
+    + ops::DerefMut<Target = [T]>
+    + Extend<T>
+{
     /// Append an element to the vector.
     fn push(&mut self, value: T);
 }
@@ -193,21 +192,17 @@ unsafe fn deallocate<T>(ptr: *mut T, capacity: usize) {
 ///
 /// [1]: struct.SmallVec.html#method.drain
 pub struct Drain<'a, T: 'a> {
-    iter: slice::IterMut<'a,T>,
+    iter: slice::IterMut<'a, T>,
 }
 
-impl<'a, T: 'a> Iterator for Drain<'a,T> {
+impl<'a, T: 'a> Iterator for Drain<'a, T> {
     type Item = T;
 
     #[inline]
     fn next(&mut self) -> Option<T> {
         match self.iter.next() {
             None => None,
-            Some(reference) => {
-                unsafe {
-                    Some(ptr::read(reference))
-                }
-            }
+            Some(reference) => unsafe { Some(ptr::read(reference)) },
         }
     }
 
@@ -222,18 +217,14 @@ impl<'a, T: 'a> DoubleEndedIterator for Drain<'a, T> {
     fn next_back(&mut self) -> Option<T> {
         match self.iter.next_back() {
             None => None,
-            Some(reference) => {
-                unsafe {
-                    Some(ptr::read(reference))
-                }
-            }
+            Some(reference) => unsafe { Some(ptr::read(reference)) },
         }
     }
 }
 
-impl<'a, T> ExactSizeIterator for Drain<'a, T> { }
+impl<'a, T> ExactSizeIterator for Drain<'a, T> {}
 
-impl<'a, T: 'a> Drop for Drain<'a,T> {
+impl<'a, T: 'a> Drop for Drain<'a, T> {
     fn drop(&mut self) {
         // Destroy the remaining elements.
         for _ in self.by_ref() {}
@@ -263,10 +254,13 @@ impl<A: Array> Drop for SmallVecData<A> {
             match *self {
                 ref mut inline @ Inline { .. } => {
                     // Inhibit the array destructor.
-                    ptr::write(inline, Heap {
-                        ptr: ptr::null_mut(),
-                        capacity: 0,
-                    });
+                    ptr::write(
+                        inline,
+                        Heap {
+                            ptr: ptr::null_mut(),
+                            capacity: 0,
+                        },
+                    );
                 }
                 Heap { ptr, capacity } => deallocate(ptr, capacity),
             }
@@ -312,7 +306,9 @@ impl<A: Array> SmallVec<A> {
         unsafe {
             SmallVec {
                 len: 0,
-                data: Inline { array: mem::uninitialized() },
+                data: Inline {
+                    array: mem::uninitialized(),
+                },
             }
         }
     }
@@ -357,8 +353,8 @@ impl<A: Array> SmallVec<A> {
             len: len,
             data: SmallVecData::Heap {
                 ptr: ptr,
-                capacity: cap
-            }
+                capacity: cap,
+            },
         }
     }
 
@@ -461,7 +457,7 @@ impl<A: Array> SmallVec<A> {
     #[inline]
     pub fn pop(&mut self) -> Option<A::Item> {
         if self.len == 0 {
-            return None
+            return None;
         }
         let last_index = self.len - 1;
         if (last_index as isize) < 0 {
@@ -490,10 +486,13 @@ impl<A: Array> SmallVec<A> {
                 Inline { .. } => {}
                 Heap { ptr, capacity } => deallocate(ptr, capacity),
             }
-            ptr::write(&mut self.data, Heap {
-                ptr: new_alloc,
-                capacity: new_cap,
-            });
+            ptr::write(
+                &mut self.data,
+                Heap {
+                    ptr: new_alloc,
+                    capacity: new_cap,
+                },
+            );
         }
     }
 
@@ -507,7 +506,9 @@ impl<A: Array> SmallVec<A> {
     pub fn reserve(&mut self, additional: usize) {
         let len = self.len();
         if self.capacity() - len < additional {
-            match len.checked_add(additional).and_then(usize::checked_next_power_of_two) {
+            match len.checked_add(additional)
+                .and_then(usize::checked_next_power_of_two)
+            {
                 Some(cap) => self.grow(cap),
                 None => self.grow(usize::max_value()),
             }
@@ -539,7 +540,12 @@ impl<A: Array> SmallVec<A> {
                     Inline { .. } => return,
                     Heap { ptr, capacity } => (ptr, capacity),
                 };
-                ptr::write(&mut self.data, Inline { array: mem::uninitialized() });
+                ptr::write(
+                    &mut self.data,
+                    Inline {
+                        array: mem::uninitialized(),
+                    },
+                );
                 ptr::copy_nonoverlapping(ptr, self.as_mut_ptr(), len);
                 deallocate(ptr, capacity);
             }
@@ -635,11 +641,11 @@ impl<A: Array> SmallVec<A> {
 
     /// Insert multiple elements at position `index`, shifting all following elements toward the
     /// back.
-    pub fn insert_many<I: IntoIterator<Item=A::Item>>(&mut self, index: usize, iterable: I) {
+    pub fn insert_many<I: IntoIterator<Item = A::Item>>(&mut self, index: usize, iterable: I) {
         let iter = iterable.into_iter();
         let (lower_size_bound, _) = iter.size_hint();
-        assert!(lower_size_bound <= std::isize::MAX as usize);  // Ensure offset is indexable
-        assert!(index + lower_size_bound >= index);  // Protect against overflow
+        assert!(lower_size_bound <= std::isize::MAX as usize); // Ensure offset is indexable
+        assert!(index + lower_size_bound >= index); // Protect against overflow
         self.reserve(lower_size_bound);
 
         unsafe {
@@ -653,14 +659,18 @@ impl<A: Array> SmallVec<A> {
                     self.len = self.len + 1;
                 } else {
                     // Iterator provided more elements than the hint.
-                    assert!(index + off >= index);  // Protect against overflow.
+                    assert!(index + off >= index); // Protect against overflow.
                     self.insert(index + off, element);
                 }
             }
             let num_added = self.len - old_len;
             if num_added < lower_size_bound {
                 // Iterator provided fewer elements than the hint
-                ptr::copy(ptr.offset(lower_size_bound as isize), ptr.offset(num_added as isize), old_len - index);
+                ptr::copy(
+                    ptr.offset(lower_size_bound as isize),
+                    ptr.offset(num_added as isize),
+                    old_len - index,
+                );
             }
         }
     }
@@ -674,7 +684,7 @@ impl<A: Array> SmallVec<A> {
                 let v = Vec::from_raw_parts(ptr, self.len, capacity);
                 mem::forget(self);
                 v
-            }
+            },
         }
     }
 
@@ -697,13 +707,17 @@ impl<A: Array> SmallVec<A> {
     }
 
     /// Removes consecutive duplicate elements.
-    pub fn dedup(&mut self) where A::Item: PartialEq<A::Item> {
+    pub fn dedup(&mut self)
+    where
+        A::Item: PartialEq<A::Item>,
+    {
         self.dedup_by(|a, b| a == b);
     }
 
     /// Removes consecutive duplicate elements using the given equality relation.
-    pub fn dedup_by<F>(&mut self, mut same_bucket: F) 
-        where F: FnMut(&mut A::Item, &mut A::Item) -> bool
+    pub fn dedup_by<F>(&mut self, mut same_bucket: F)
+    where
+        F: FnMut(&mut A::Item, &mut A::Item) -> bool,
     {
         // See the implementation of Vec::dedup_by in the
         // standard library for an explanation of this algorithm.
@@ -733,15 +747,19 @@ impl<A: Array> SmallVec<A> {
     }
 
     /// Removes consecutive elements that map to the same key.
-    pub fn dedup_by_key<F, K>(&mut self, mut key: F) 
-        where F: FnMut(&mut A::Item) -> K, 
-              K: PartialEq<K> 
+    pub fn dedup_by_key<F, K>(&mut self, mut key: F)
+    where
+        F: FnMut(&mut A::Item) -> K,
+        K: PartialEq<K>,
     {
         self.dedup_by(|a, b| key(a) == key(b));
     }
 }
 
-impl<A: Array> SmallVec<A> where A::Item: Copy {
+impl<A: Array> SmallVec<A>
+where
+    A::Item: Copy,
+{
     /// Copy the elements from a slice into a new `SmallVec`.
     ///
     /// For slices of `Copy` types, this is more efficient than `SmallVec::from(slice)`.
@@ -780,7 +798,10 @@ impl<A: Array> SmallVec<A> where A::Item: Copy {
     }
 }
 
-impl<A: Array> SmallVec<A> where A::Item: Clone {
+impl<A: Array> SmallVec<A>
+where
+    A::Item: Clone,
+{
     /// Resizes the vector so that its length is equal to `len`.
     ///
     /// If `len` is less than the current length, the vector simply truncated.
@@ -800,7 +821,7 @@ impl<A: Array> SmallVec<A> where A::Item: Clone {
     /// Creates a `SmallVec` with `n` copies of `elem`.
     /// ```
     /// use smallvec::SmallVec;
-    /// 
+    ///
     /// let v = SmallVec::<[char; 128]>::from_elem('d', 2);
     /// assert_eq!(v, SmallVec::from_buf(['d', 'd']));
     /// ```
@@ -819,9 +840,7 @@ impl<A: Array> ops::Deref for SmallVec<A> {
             Inline { ref array } => array.ptr(),
             Heap { ptr, .. } => ptr,
         };
-        unsafe {
-            slice::from_raw_parts(ptr, self.len)
-        }
+        unsafe { slice::from_raw_parts(ptr, self.len) }
     }
 }
 
@@ -829,9 +848,7 @@ impl<A: Array> ops::DerefMut for SmallVec<A> {
     #[inline]
     fn deref_mut(&mut self) -> &mut [A::Item] {
         let ptr = self.data.ptr_mut();
-        unsafe {
-            slice::from_raw_parts_mut(ptr, self.len)
-        }
+        unsafe { slice::from_raw_parts_mut(ptr, self.len) }
     }
 }
 
@@ -884,7 +901,10 @@ impl<A: Array<Item = u8>> io::Write for SmallVec<A> {
 }
 
 #[cfg(feature = "serde")]
-impl<A: Array> Serialize for SmallVec<A> where A::Item: Serialize {
+impl<A: Array> Serialize for SmallVec<A>
+where
+    A::Item: Serialize,
+{
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let mut state = serializer.serialize_seq(Some(self.len()))?;
         for item in self {
@@ -895,20 +915,26 @@ impl<A: Array> Serialize for SmallVec<A> where A::Item: Serialize {
 }
 
 #[cfg(feature = "serde")]
-impl<'de, A: Array> Deserialize<'de> for SmallVec<A> where A::Item: Deserialize<'de> {
+impl<'de, A: Array> Deserialize<'de> for SmallVec<A>
+where
+    A::Item: Deserialize<'de>,
+{
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        deserializer.deserialize_seq(SmallVecVisitor{phantom: PhantomData})
+        deserializer.deserialize_seq(SmallVecVisitor {
+            phantom: PhantomData,
+        })
     }
 }
 
 #[cfg(feature = "serde")]
 struct SmallVecVisitor<A> {
-    phantom: PhantomData<A>
+    phantom: PhantomData<A>,
 }
 
 #[cfg(feature = "serde")]
 impl<'de, A: Array> Visitor<'de> for SmallVecVisitor<A>
-where A::Item: Deserialize<'de>,
+where
+    A::Item: Deserialize<'de>,
 {
     type Value = SmallVec<A>;
 
@@ -917,8 +943,8 @@ where A::Item: Deserialize<'de>,
     }
 
     fn visit_seq<B>(self, mut seq: B) -> Result<Self::Value, B::Error>
-        where
-            B: SeqAccess<'de>,
+    where
+        B: SeqAccess<'de>,
     {
         let len = seq.size_hint().unwrap_or(0);
         let mut values = SmallVec::with_capacity(len);
@@ -931,7 +957,10 @@ where A::Item: Deserialize<'de>,
     }
 }
 
-impl<'a, A: Array> From<&'a [A::Item]> for SmallVec<A> where A::Item: Clone {
+impl<'a, A: Array> From<&'a [A::Item]> for SmallVec<A>
+where
+    A::Item: Clone,
+{
     #[inline]
     fn from(slice: &'a [A::Item]) -> SmallVec<A> {
         slice.into_iter().cloned().collect()
@@ -953,7 +982,7 @@ impl<A: Array> From<A> for SmallVec<A> {
 }
 
 macro_rules! impl_index {
-    ($index_type: ty, $output_type: ty) => {
+    ($index_type:ty, $output_type:ty) => {
         impl<A: Array> ops::Index<$index_type> for SmallVec<A> {
             type Output = $output_type;
             #[inline]
@@ -968,7 +997,7 @@ macro_rules! impl_index {
                 &mut (&mut **self)[index]
             }
         }
-    }
+    };
 }
 
 impl_index!(usize, A::Item);
@@ -977,7 +1006,10 @@ impl_index!(ops::RangeFrom<usize>, [A::Item]);
 impl_index!(ops::RangeTo<usize>, [A::Item]);
 impl_index!(ops::RangeFull, [A::Item]);
 
-impl<A: Array> ExtendFromSlice<A::Item> for SmallVec<A> where A::Item: Copy {
+impl<A: Array> ExtendFromSlice<A::Item> for SmallVec<A>
+where
+    A::Item: Copy,
+{
     fn extend_from_slice(&mut self, other: &[A::Item]) {
         SmallVec::extend_from_slice(self, other)
     }
@@ -992,7 +1024,7 @@ impl<A: Array> VecLike<A::Item> for SmallVec<A> {
 }
 
 impl<A: Array> FromIterator<A::Item> for SmallVec<A> {
-    fn from_iter<I: IntoIterator<Item=A::Item>>(iterable: I) -> SmallVec<A> {
+    fn from_iter<I: IntoIterator<Item = A::Item>>(iterable: I) -> SmallVec<A> {
         let mut v = SmallVec::new();
         v.extend(iterable);
         v
@@ -1000,14 +1032,14 @@ impl<A: Array> FromIterator<A::Item> for SmallVec<A> {
 }
 
 impl<A: Array> Extend<A::Item> for SmallVec<A> {
-    fn extend<I: IntoIterator<Item=A::Item>>(&mut self, iterable: I) {
+    fn extend<I: IntoIterator<Item = A::Item>>(&mut self, iterable: I) {
         let iter = iterable.into_iter();
         let (lower_size_bound, _) = iter.size_hint();
 
         let target_len = self.len + lower_size_bound;
 
         if target_len > self.capacity() {
-           self.grow(target_len);
+            self.grow(target_len);
         }
 
         for elem in iter {
@@ -1016,7 +1048,10 @@ impl<A: Array> Extend<A::Item> for SmallVec<A> {
     }
 }
 
-impl<A: Array> fmt::Debug for SmallVec<A> where A::Item: fmt::Debug {
+impl<A: Array> fmt::Debug for SmallVec<A>
+where
+    A::Item: fmt::Debug,
+{
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{:?}", &**self)
     }
@@ -1035,14 +1070,17 @@ impl<A: Array> Drop for SmallVec<A> {
         // but the inner SmallVecData destructor will still run
         unsafe {
             let ptr = self.as_ptr();
-            for i in 0 .. self.len {
+            for i in 0..self.len {
                 ptr::read(ptr.offset(i as isize));
             }
         }
     }
 }
 
-impl<A: Array> Clone for SmallVec<A> where A::Item: Clone {
+impl<A: Array> Clone for SmallVec<A>
+where
+    A::Item: Clone,
+{
     fn clone(&self) -> SmallVec<A> {
         let mut new_vector = SmallVec::with_capacity(self.len());
         for element in self.iter() {
@@ -1053,36 +1091,59 @@ impl<A: Array> Clone for SmallVec<A> where A::Item: Clone {
 }
 
 impl<A: Array, B: Array> PartialEq<SmallVec<B>> for SmallVec<A>
-    where A::Item: PartialEq<B::Item> {
+where
+    A::Item: PartialEq<B::Item>,
+{
     #[inline]
-    fn eq(&self, other: &SmallVec<B>) -> bool { self[..] == other[..] }
+    fn eq(&self, other: &SmallVec<B>) -> bool {
+        self[..] == other[..]
+    }
     #[inline]
-    fn ne(&self, other: &SmallVec<B>) -> bool { self[..] != other[..] }
+    fn ne(&self, other: &SmallVec<B>) -> bool {
+        self[..] != other[..]
+    }
 }
 
-impl<A: Array> Eq for SmallVec<A> where A::Item: Eq {}
+impl<A: Array> Eq for SmallVec<A>
+where
+    A::Item: Eq,
+{
+}
 
-impl<A: Array> PartialOrd for SmallVec<A> where A::Item: PartialOrd {
+impl<A: Array> PartialOrd for SmallVec<A>
+where
+    A::Item: PartialOrd,
+{
     #[inline]
     fn partial_cmp(&self, other: &SmallVec<A>) -> Option<cmp::Ordering> {
         PartialOrd::partial_cmp(&**self, &**other)
     }
 }
 
-impl<A: Array> Ord for SmallVec<A> where A::Item: Ord {
+impl<A: Array> Ord for SmallVec<A>
+where
+    A::Item: Ord,
+{
     #[inline]
     fn cmp(&self, other: &SmallVec<A>) -> cmp::Ordering {
         Ord::cmp(&**self, &**other)
     }
 }
 
-impl<A: Array> Hash for SmallVec<A> where A::Item: Hash {
+impl<A: Array> Hash for SmallVec<A>
+where
+    A::Item: Hash,
+{
     fn hash<H: Hasher>(&self, state: &mut H) {
         (**self).hash(state)
     }
 }
 
-unsafe impl<A: Array> Send for SmallVec<A> where A::Item: Send {}
+unsafe impl<A: Array> Send for SmallVec<A>
+where
+    A::Item: Send,
+{
+}
 
 /// An iterator that consumes a `SmallVec` and yields its items by value.
 ///
@@ -1097,7 +1158,7 @@ pub struct IntoIter<A: Array> {
 
 impl<A: Array> Drop for IntoIter<A> {
     fn drop(&mut self) {
-        for _ in self { }
+        for _ in self {}
     }
 }
 
@@ -1108,8 +1169,7 @@ impl<A: Array> Iterator for IntoIter<A> {
     fn next(&mut self) -> Option<A::Item> {
         if self.current == self.end {
             None
-        }
-        else {
+        } else {
             unsafe {
                 let current = self.current as isize;
                 self.current += 1;
@@ -1130,8 +1190,7 @@ impl<A: Array> DoubleEndedIterator for IntoIter<A> {
     fn next_back(&mut self) -> Option<A::Item> {
         if self.current == self.end {
             None
-        }
-        else {
+        } else {
             unsafe {
                 self.end -= 1;
                 Some(ptr::read(self.data.ptr_mut().offset(self.end as isize)))
@@ -1140,7 +1199,7 @@ impl<A: Array> DoubleEndedIterator for IntoIter<A> {
     }
 }
 
-impl<A: Array> ExactSizeIterator for IntoIter<A> { }
+impl<A: Array> ExactSizeIterator for IntoIter<A> {}
 
 impl<A: Array> IntoIterator for SmallVec<A> {
     type IntoIter = IntoIter<A>;
@@ -1201,9 +1260,11 @@ macro_rules! impl_array(
     }
 );
 
-impl_array!(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 20, 24, 32, 36,
-            0x40, 0x80, 0x100, 0x200, 0x400, 0x800, 0x1000, 0x2000, 0x4000, 0x8000,
-            0x10000, 0x20000, 0x40000, 0x80000, 0x100000);
+impl_array!(
+    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 20, 24, 32, 36, 0x40, 0x80, 0x100,
+    0x200, 0x400, 0x800, 0x1000, 0x2000, 0x4000, 0x8000, 0x10000, 0x20000, 0x40000, 0x80000,
+    0x100000
+);
 
 #[cfg(test)]
 mod tests {
@@ -1211,18 +1272,18 @@ mod tests {
 
     use std::iter::FromIterator;
 
-    #[cfg(feature = "std")]
-    use std::borrow::ToOwned;
     #[cfg(not(feature = "std"))]
     use alloc::borrow::ToOwned;
-    #[cfg(feature = "std")]
-    use std::rc::Rc;
-    #[cfg(not(feature = "std"))]
-    use alloc::rc::Rc;
     #[cfg(not(feature = "std"))]
     use alloc::boxed::Box;
     #[cfg(not(feature = "std"))]
+    use alloc::rc::Rc;
+    #[cfg(not(feature = "std"))]
     use alloc::vec::Vec;
+    #[cfg(feature = "std")]
+    use std::borrow::ToOwned;
+    #[cfg(feature = "std")]
+    use std::rc::Rc;
 
     #[test]
     pub fn test_zero() {
@@ -1240,10 +1301,7 @@ mod tests {
         let mut v = SmallVec::<[_; 16]>::new();
         v.push("hello".to_owned());
         v.push("there".to_owned());
-        assert_eq!(&*v, &[
-            "hello".to_owned(),
-            "there".to_owned(),
-        ][..]);
+        assert_eq!(&*v, &["hello".to_owned(), "there".to_owned()][..]);
     }
 
     #[test]
@@ -1255,12 +1313,15 @@ mod tests {
         v.push("burma".to_owned());
         assert_eq!(v[0], "hello");
         v.push("shave".to_owned());
-        assert_eq!(&*v, &[
-            "hello".to_owned(),
-            "there".to_owned(),
-            "burma".to_owned(),
-            "shave".to_owned(),
-        ][..]);
+        assert_eq!(
+            &*v,
+            &[
+                "hello".to_owned(),
+                "there".to_owned(),
+                "burma".to_owned(),
+                "shave".to_owned(),
+            ][..]
+        );
     }
 
     #[test]
@@ -1274,16 +1335,19 @@ mod tests {
         v.push("there".to_owned());
         v.push("burma".to_owned());
         v.push("shave".to_owned());
-        assert_eq!(&*v, &[
-            "hello".to_owned(),
-            "there".to_owned(),
-            "burma".to_owned(),
-            "shave".to_owned(),
-            "hello".to_owned(),
-            "there".to_owned(),
-            "burma".to_owned(),
-            "shave".to_owned(),
-        ][..]);
+        assert_eq!(
+            &*v,
+            &[
+                "hello".to_owned(),
+                "there".to_owned(),
+                "burma".to_owned(),
+                "shave".to_owned(),
+                "hello".to_owned(),
+                "there".to_owned(),
+                "burma".to_owned(),
+                "shave".to_owned(),
+            ][..]
+        );
     }
 
     /// https://github.com/servo/rust-smallvec/issues/4
@@ -1464,14 +1528,24 @@ mod tests {
         }
         assert_eq!(v.len(), 4);
         v.insert_many(1, [5, 6].iter().cloned());
-        assert_eq!(&v.iter().map(|v| *v).collect::<Vec<_>>(), &[0, 5, 6, 1, 2, 3]);
+        assert_eq!(
+            &v.iter().map(|v| *v).collect::<Vec<_>>(),
+            &[0, 5, 6, 1, 2, 3]
+        );
     }
 
-    struct MockHintIter<T: Iterator>{x: T, hint: usize}
+    struct MockHintIter<T: Iterator> {
+        x: T,
+        hint: usize,
+    }
     impl<T: Iterator> Iterator for MockHintIter<T> {
         type Item = T::Item;
-        fn next(&mut self) -> Option<Self::Item> {self.x.next()}
-        fn size_hint(&self) -> (usize, Option<usize>) {(self.hint, None)}
+        fn next(&mut self) -> Option<Self::Item> {
+            self.x.next()
+        }
+        fn size_hint(&self) -> (usize, Option<usize>) {
+            (self.hint, None)
+        }
     }
 
     #[test]
@@ -1481,8 +1555,17 @@ mod tests {
             v.push(x);
         }
         assert_eq!(v.len(), 4);
-        v.insert_many(1, MockHintIter{x: [5, 6].iter().cloned(), hint: 5});
-        assert_eq!(&v.iter().map(|v| *v).collect::<Vec<_>>(), &[0, 5, 6, 1, 2, 3]);
+        v.insert_many(
+            1,
+            MockHintIter {
+                x: [5, 6].iter().cloned(),
+                hint: 5,
+            },
+        );
+        assert_eq!(
+            &v.iter().map(|v| *v).collect::<Vec<_>>(),
+            &[0, 5, 6, 1, 2, 3]
+        );
     }
 
     #[test]
@@ -1492,8 +1575,17 @@ mod tests {
             v.push(x);
         }
         assert_eq!(v.len(), 4);
-        v.insert_many(1, MockHintIter{x: [5, 6].iter().cloned(), hint: 1});
-        assert_eq!(&v.iter().map(|v| *v).collect::<Vec<_>>(), &[0, 5, 6, 1, 2, 3]);
+        v.insert_many(
+            1,
+            MockHintIter {
+                x: [5, 6].iter().cloned(),
+                hint: 1,
+            },
+        );
+        assert_eq!(
+            &v.iter().map(|v| *v).collect::<Vec<_>>(),
+            &[0, 5, 6, 1, 2, 3]
+        );
     }
 
     #[test]
@@ -1512,7 +1604,10 @@ mod tests {
         }
         assert_eq!(v.len(), 4);
         v.insert_from_slice(1, &[5, 6]);
-        assert_eq!(&v.iter().map(|v| *v).collect::<Vec<_>>(), &[0, 5, 6, 1, 2, 3]);
+        assert_eq!(
+            &v.iter().map(|v| *v).collect::<Vec<_>>(),
+            &[0, 5, 6, 1, 2, 3]
+        );
     }
 
     #[test]
@@ -1523,7 +1618,10 @@ mod tests {
         }
         assert_eq!(v.len(), 4);
         v.extend_from_slice(&[5, 6]);
-        assert_eq!(&v.iter().map(|v| *v).collect::<Vec<_>>(), &[0, 1, 2, 3, 5, 6]);
+        assert_eq!(
+            &v.iter().map(|v| *v).collect::<Vec<_>>(),
+            &[0, 1, 2, 3, 5, 6]
+        );
     }
 
     #[test]
@@ -1585,8 +1683,8 @@ mod tests {
     #[cfg(feature = "std")]
     #[test]
     fn test_hash() {
-        use std::hash::Hash;
         use std::collections::hash_map::DefaultHasher;
+        use std::hash::Hash;
 
         {
             let mut a: SmallVec<[u32; 2]> = SmallVec::new();
@@ -1690,7 +1788,10 @@ mod tests {
     #[test]
     fn test_from_slice() {
         assert_eq!(&SmallVec::<[u32; 2]>::from_slice(&[1][..])[..], [1]);
-        assert_eq!(&SmallVec::<[u32; 2]>::from_slice(&[1, 2, 3][..])[..], [1, 2, 3]);
+        assert_eq!(
+            &SmallVec::<[u32; 2]>::from_slice(&[1, 2, 3][..])[..],
+            [1, 2, 3]
+        );
     }
 
     #[test]
@@ -1856,7 +1957,7 @@ mod tests {
     #[cfg(feature = "serde")]
     #[test]
     fn test_serde() {
-        use self::bincode::{serialize, deserialize, Bounded};
+        use self::bincode::{deserialize, serialize, Bounded};
         let mut small_vec: SmallVec<[i32; 2]> = SmallVec::new();
         small_vec.push(1);
         let encoded = serialize(&small_vec, Bounded(100)).unwrap();


### PR DESCRIPTION
Uses a union to eliminate the space used by the `enum` determinant. The new layout looks like this:
```rust
struct SmallVec<A> {
    capacity: usize,
    union {
        inline: ManuallyDrop<A>,
        heap: struct {
            ptr: *mut A::Item, 
            len: usize,
        } 
    }
}
```

The `capacity` field is used to determine which of the two union variants is active:
- If `capacity <= A::size()` then the inline variant is used and `capacity` holds the current length of the vector (number of elements actually in use).
- If `capacity > A::size()` then the heap variant is used and `capacity` holds the size of the memory allocation.

Since unions with drop are still currently unstable, this is kept behind a "union" cargo feature, which falls back to an implementation using an enum if disabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-smallvec/92)
<!-- Reviewable:end -->
