### PR TITLE
Optimize `extend` and `from_elem`

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -810,7 +810,7 @@ impl<A: Array> SmallVec<A> where A::Item: Clone {
     /// ```
     pub fn from_elem(elem: A::Item, n: usize) -> Self {
         if n > A::size() {
-            ::std::vec::from_elem(elem, n).into()
+            vec![elem; n].into()
         } else {
             unsafe {
                 let mut arr: A = ::std::mem::uninitialized();

--- a/lib.rs
+++ b/lib.rs
@@ -21,7 +21,7 @@
 
 
 #[cfg(not(feature = "std"))]
-#[cfg_attr(test, macro_use)]
+#[macro_use]
 extern crate alloc;
 
 #[cfg(not(feature = "std"))]


### PR DESCRIPTION
This increases the amount of unsafe code, and so should be carefully checked. However, the use of unsafe code is quite benign and depends only on the invariant that `grow` always succeeds (which is depended on other places in the codebase)

Benchcmp results:

```
 name                     preopt.bench ns/iter  postopt.bench ns/iter  diff ns/iter   diff %  speedup 
 bench_extend             277                   89                             -188  -67.87%   x 3.11  
 bench_macro_from_elem    214                   61                             -153  -71.50%   x 3.51 
```

I took a crack at this after noticing how awful the generated assembly for `SmallVec::from_elem` is even for really simple types like integers. It's still not great but it at least now for the case of `Copy` types it gets autovectorised. Probably someone could make it even better if they spent more time on it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-smallvec/93)
<!-- Reviewable:end -->
