### PR TITLE
Use a union to reduce the size of SmallVec [v2]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,9 @@ rust:
   - stable
 script: |
   cargo build --verbose &&
-  cargo build --all-features --verbose &&
   cargo test --verbose &&
-  cargo test --all-features --verbose &&
   ([ $TRAVIS_RUST_VERSION != nightly ] || cargo test --verbose --no-default-features) &&
+  ([ $TRAVIS_RUST_VERSION != nightly ] || cargo test --verbose --features union) &&
   ([ $TRAVIS_RUST_VERSION != nightly ] || cargo bench --verbose bench)
 notifications:
   webhooks: http://build.servo.org:54856/travis

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ documentation = "http://doc.servo.org/smallvec/"
 
 [features]
 std = []
+union = []
 default = ["std"]
 
 [lib]
@@ -19,6 +20,8 @@ name = "smallvec"
 path = "lib.rs"
 
 [dependencies]
+unreachable = "1.0.0"
+debug_unreachable = "0.1"
 serde = { version = "1", optional = true }
 
 [dev_dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ path = "lib.rs"
 
 [dependencies]
 unreachable = "1.0.0"
-debug_unreachable = "0.1"
 serde = { version = "1", optional = true }
 
 [dev_dependencies]

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -158,15 +158,15 @@ fn gen_insert<V: Vector<u64>>(n: u64, b: &mut Bencher) {
 
 fn gen_remove<V: Vector<u64>>(n: usize, b: &mut Bencher) {
     #[inline(never)]
-    fn remove_noinline<V: Vector<u64>>(vec: &mut V, p: usize) {
-        vec.remove(p);
+    fn remove_noinline<V: Vector<u64>>(vec: &mut V, p: usize) -> u64 {
+        vec.remove(p)
     }
 
     b.iter(|| {
         let mut vec = V::from_elem(0, n as _);
 
         for x in (0..n - 1).rev() {
-            remove_noinline(&mut vec, x)
+            remove_noinline(&mut vec, x);
         }
     });
 }

--- a/lib.rs
+++ b/lib.rs
@@ -14,6 +14,17 @@
 //!
 //! To depend on `smallvec` without `libstd`, use `default-features = false` in the `smallvec`
 //! section of Cargo.toml to disable its `"std"` feature.
+//!
+//! ## `union` feature
+//!
+//! When the `union` feature is enabled `smallvec` will track its state (inline or spilled)
+//! without the use of an enum tag, reducing the size of the `smallvec` by one machine word.
+//! This means that there is potentially no space overhead compared to `Vec`.
+//! Note that `smallvec` can still be larger than `Vec` if the inline buffer is larger than two
+//! machine words.
+//!
+//! To use this feature add `features = ["union"]` in the `smallvec` section of Cargo.toml.
+//! Note that this feature requires a nightly compiler (for now).
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(not(feature = "std"), feature(alloc))]


### PR DESCRIPTION
Building on top of #92 by @Amanieu 

I introduced `triple()` and `triple_mut()` which removed almost all of the runtime overhead. Performance is very comparable.

```
 name                     master:: ns/iter  union:: ns/iter  diff ns/iter   diff %  speedup 
 bench_extend             45                47                          2    4.44%   x 0.96 
 bench_extend_from_slice  45                43                         -2   -4.44%   x 1.05 
 bench_from_slice         45                44                         -1   -2.22%   x 1.02 
 bench_insert             615               622                         7    1.14%   x 0.99 
 bench_insert_from_slice  101               99                         -2   -1.98%   x 1.02 
 bench_insert_many        309               266                       -43  -13.92%   x 1.16 
 bench_macro_from_elem    41                37                         -4   -9.76%   x 1.11 
 bench_macro_from_list    40                42                          2    5.00%   x 0.95 
 bench_push               381               370                       -11   -2.89%   x 1.03 
 bench_pushpop            404               420                        16    3.96%   x 0.96 
 bench_remove             458               436                       -22   -4.80%   x 1.05 
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-smallvec/94)
<!-- Reviewable:end -->
