### PR TITLE
Add benchmarks for Vec to compare to SmallVec

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -130,3 +130,99 @@ fn bench_macro_from_list(b: &mut Bencher) {
         vec
     });
 }
+#[bench]
+fn bench_push_vec(b: &mut Bencher) {
+    #[inline(never)]
+    fn push_noinline(vec: &mut Vec<u64>, x: u64) {
+        vec.push(x)
+    }
+
+    b.iter(|| {
+        let mut vec: Vec<u64> = Vec::with_capacity(16);
+        for x in 0..100 {
+            push_noinline(&mut vec, x);
+        }
+        vec
+    });
+}
+
+#[bench]
+fn bench_insert_vec(b: &mut Bencher) {
+    #[inline(never)]
+    fn insert_noinline(vec: &mut Vec<u64>, x: u64) {
+        vec.insert(0, x)
+    }
+
+    b.iter(|| {
+        let mut vec: Vec<u64> = Vec::with_capacity(16);
+        for x in 0..100 {
+            insert_noinline(&mut vec, x);
+        }
+        vec
+    });
+}
+
+#[bench]
+fn bench_extend_vec(b: &mut Bencher) {
+    b.iter(|| {
+        let mut vec: Vec<u64> = Vec::with_capacity(16);
+        vec.extend(0..100);
+        vec
+    });
+}
+
+#[bench]
+fn bench_from_slice_vec(b: &mut Bencher) {
+    let v: Vec<u64> = (0..100).collect();
+    b.iter(|| {
+        let vec: Vec<u64> = Vec::from(&v[..]);
+        vec
+    });
+}
+
+#[bench]
+fn bench_extend_from_slice_vec(b: &mut Bencher) {
+    let v: Vec<u64> = (0..100).collect();
+    b.iter(|| {
+        let mut vec: Vec<u64> = Vec::with_capacity(16);
+        vec.extend_from_slice(&v);
+        vec
+    });
+}
+
+#[bench]
+fn bench_pushpop_vec(b: &mut Bencher) {
+    #[inline(never)]
+    fn pushpop_noinline(vec: &mut Vec<u64>, x: u64) {
+        vec.push(x);
+        vec.pop();
+    }
+
+    b.iter(|| {
+        let mut vec: Vec<u64> = Vec::with_capacity(16);
+        for x in 0..100 {
+            pushpop_noinline(&mut vec, x);
+        }
+        vec
+    });
+}
+
+#[bench]
+fn bench_macro_from_elem_vec(b: &mut Bencher) {
+    b.iter(|| {
+        let vec: Vec<u64> = vec![42; 100];
+        vec
+    });
+}
+
+#[bench]
+fn bench_macro_from_list_vec(b: &mut Bencher) {
+    b.iter(|| {
+        let vec: Vec<u64> = vec![
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 20, 24, 32, 36, 0x40, 0x80,
+            0x100, 0x200, 0x400, 0x800, 0x1000, 0x2000, 0x4000, 0x8000, 0x10000, 0x20000, 0x40000,
+            0x80000, 0x100000
+        ];
+        vec
+    });
+}


### PR DESCRIPTION
Preliminary results aren't good, although no benches check for cache efficiency (for example `Vec<Vec<T>>` vs `Vec<SmallVec<[T; N]>>`).

Here's a comparison. I used `sed` to split the `_vec` benchmarks out and rename them to have the same name, so `cargo benchcmp` can understand them.

```
 name                     vec.bench ns/iter          smallvec.bench ns/iter          diff ns/iter   diff %  speedup 
 bench_extend             69                         53                                       -16  -23.19%   x 1.30 
 bench_extend_from_slice  64                         52                                       -12  -18.75%   x 1.23 
 bench_from_slice         34                         52                                        18   52.94%   x 0.65 
 bench_insert             1,228                      1,202                                    -26   -2.12%   x 1.02 
 bench_macro_from_elem    50                         66                                        16   32.00%   x 0.76 
 bench_macro_from_list    33                         47                                        14   42.42%   x 0.70 
 bench_push               359                        424                                       65   18.11%   x 0.85 
 bench_pushpop            251                        348                                       97   38.65%   x 0.72 
```

Closes #87

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-smallvec/95)
<!-- Reviewable:end -->
