### PR TITLE
Use a single ptr::drop_in_place call instead of a loop

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -1186,10 +1186,7 @@ impl<A: Array> Drop for SmallVec<A> {
                 let (ptr, len) = self.data.heap();
                 Vec::from_raw_parts(ptr, len, self.capacity);
             } else {
-                let ptr = self.as_mut_ptr();
-                for i in 0..self.len() {
-                    ptr::drop_in_place(ptr.offset(i as isize));
-                }
+                ptr::drop_in_place(&mut self[..]);
             }
         }
     }


### PR DESCRIPTION
This is what the standard Vec does; see rust-lang/rust#32012.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-smallvec/100)
<!-- Reviewable:end -->
