### PR TITLE
Version 0.6.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smallvec"
-version = "0.6.1"
+version = "0.6.3"
 authors = ["Simon Sapin <simon.sapin@exyr.org>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/servo/rust-smallvec"


### PR DESCRIPTION
Changes in this release:

* Fix possible double-free in `insert_many` when passed an iterator that panics in `next` (#103)
* Add a new `union` feature (disabled by default) that reduces the size of the SmallVec struct (#94)
* Improve performance of `extend` and `from_elem` (#93)
* Improve performance of `drop` (#100)
* Update to build without `std` feature on current Rust nightly (#104)
* Additional benchmarks (#95, #97)
* Update dev-dependency on `bincode` (#102)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-smallvec/105)
<!-- Reviewable:end -->
