### PR TITLE
Allow smallvec! with non-Copy items

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -113,11 +113,20 @@ use std::marker::PhantomData;
 
 #[macro_export]
 macro_rules! smallvec {
+    // count helper: transform any expression into 1
+    (@one $x:expr) => (1usize);
     ($elem:expr; $n:expr) => ({
-        SmallVec::from_elem($elem, $n)
+        $crate::SmallVec::from_elem($elem, $n)
     });
     ($($x:expr),*$(,)*) => ({
-        SmallVec::from_slice(&[$($x),*])
+        let count = 0usize $(+ smallvec!(@one $x))*;
+        let mut vec = $crate::SmallVec::new();
+        if count <= vec.inline_size() {
+            $(vec.push($x);)*
+            vec
+        } else {
+            $crate::SmallVec::from_vec(vec![$($x,)*])
+        }
     });
 }
 


### PR DESCRIPTION
When count of items is smaller or equal than the target inline size, macro will use `SmallVec::push`, but when it's large enough, it passes data on to `vec!` macro for in-place heap allocation and then uses `SmallVec::from_vec`.

This trick gives ~3.5x performance increase on `bench_macro_from_list` compared to `SmallVec::with_capacity`.

Fixes #98.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-smallvec/107)
<!-- Reviewable:end -->
