### PR TITLE
Improved debug implementation.

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -1184,7 +1184,7 @@ impl<A: Array> Extend<A::Item> for SmallVec<A> {
 
 impl<A: Array> fmt::Debug for SmallVec<A> where A::Item: fmt::Debug {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}", &**self)
+        f.debug_list().entries(self.iter()).finish()
     }
 }
 


### PR DESCRIPTION
Before SmallVec would use "{:?}" style debug info no matter what the programmer specified. This pull request makes it much more inline with what Vec does by replacing the previous implementation with DebugList.

See: [https://doc.rust-lang.org/std/fmt/struct.Formatter.html#method.debug_list](https://doc.rust-lang.org/std/fmt/struct.Formatter.html#method.debug_list)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-smallvec/109)
<!-- Reviewable:end -->
