### PR TITLE
Use `reserve` instead of unchecked math in `push`

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -574,7 +574,7 @@ impl<A: Array> SmallVec<A> {
         unsafe {
             let (_, &mut len, cap) = self.triple_mut();
             if len == cap {
-                self.grow(cmp::max(cap * 2, 1))
+                self.reserve(1);
             }
             let (ptr, len_ptr, _) = self.triple_mut();
             *len_ptr = len + 1;
@@ -632,6 +632,7 @@ impl<A: Array> SmallVec<A> {
     /// If the new capacity would overflow `usize` then it will be set to `usize::max_value()`
     /// instead. (This means that inserting `additional` new elements is not guaranteed to be
     /// possible after calling this function.)
+    #[inline]
     pub fn reserve(&mut self, additional: usize) {
         // prefer triple_mut() even if triple() would work
         // so that the optimizer removes duplicated calls to it


### PR DESCRIPTION
`push` currently uses this line to reserve space in the vector:

```
self.grow(cmp::max(cap * 2, 1))
```

This risks overflowing `usize`.  In practice this can't happen currently, because `cap` can't be larger than `isize::MAX` because of invariants upheld in liballoc, but this is not easy to see.

Replacing this with `self.reserve(1)` is clearer, easier to reason about safety (because `reserve` uses checked arithmetic), and will make it easier to change the growth strategy in the future.

This does not regress any of the `push` benchmarks.  Marking `reserve` as inline is necessary to prevent `insert` benchmarks from regressing because of a change in the optimizer's inlining decisions there.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-smallvec/112)
<!-- Reviewable:end -->
