### PR TITLE
disable std::panic::catch_unwind-using test on no_std

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -1700,6 +1700,7 @@ mod tests {
         assert_eq!(&v.iter().map(|v| *v).collect::<Vec<_>>(), &[0, 5, 6, 1, 2, 3]);
     }
 
+    #[cfg(feature = "std")]
     #[test]
     // https://github.com/servo/rust-smallvec/issues/96
     fn test_insert_many_panic() {


### PR DESCRIPTION
This fixes #119

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-smallvec/120)
<!-- Reviewable:end -->
