### PR TITLE
fix from_slice possible overallocation

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -958,10 +958,10 @@ impl<A: Array> SmallVec<A> where A::Item: Copy {
             }
         } else {
             let mut b = slice.to_vec();
-            let ptr = b.as_mut_ptr();
+            let (ptr, cap) = (b.as_mut_ptr(), b.capacity());
             mem::forget(b);
             SmallVec {
-                capacity: len,
+                capacity: cap,
                 data: SmallVecData::from_heap(ptr, len),
             }
         }


### PR DESCRIPTION
@arthurps found that the code would underreport the vec's capacity
if `slice.to_vec()` allocated more than `len` entries. This
changes the code to set the correct capacity as reported from the
`vec`.