### PR TITLE
Add a new feature, `may_dangle`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smallvec"
-version = "0.6.6"
+version = "0.6.7"
 authors = ["Simon Sapin <simon.sapin@exyr.org>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/servo/rust-smallvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ std = []
 union = []
 default = ["std"]
 specialization = []
+may_dangle = []
 
 [lib]
 name = "smallvec"


### PR DESCRIPTION
This commit adds a `may_dangle` annotation to `drop`, matching `Vec`.
This feature increases the ability of `SmallVec` to be used as a drop-in
replacement for `Vec`. A feature is necessary because `may_dangle` is
Nightly-only.

Fixes #132.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-smallvec/133)
<!-- Reviewable:end -->
