### PR TITLE
Remove dependency on unmaintained 'unreachable' crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ name = "smallvec"
 path = "lib.rs"
 
 [dependencies]
-unreachable = "1.0.0"
 serde = { version = "1", optional = true }
 
 [dev_dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smallvec"
-version = "0.6.8"
+version = "0.6.9"
 authors = ["Simon Sapin <simon.sapin@exyr.org>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/servo/rust-smallvec"


### PR DESCRIPTION
Fixes #128 by inlining the tiny amount of code we use from `unreachable` and its dependency `void`.  Eventually this can be replaced with `std::hint::unrechable_unchecked` but this will require bumping our minumum supported Rust version.

This will prevent build breakage from users building with broken versions of the `void` crate, as in crossbeam-rs/crossbeam#312.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-smallvec/140)
<!-- Reviewable:end -->
