### PR TITLE
Fix using `grow` to the same size.

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -665,6 +665,8 @@ impl<A: Array> SmallVec<A> {
                 if unspilled {
                     return;
                 }
+            } else {
+                return;
             }
             deallocate(ptr, cap);
         }
@@ -2340,5 +2342,19 @@ mod tests {
         let mut v: SmallVec<[char; 4]> = SmallVec::new();
         v.extend(it);
         assert_eq!(v[..], ['a']);
+    }
+
+    #[test]
+    fn grow_spilled_same_size() {
+        let mut v: SmallVec<[u8; 2]> = SmallVec::new();
+        v.push(0);
+        v.push(1);
+        v.push(2);
+        assert!(v.spilled());
+        assert_eq!(v.capacity(), 4);
+        // grow with the same capacity
+        v.grow(4);
+        assert_eq!(v.capacity(), 4);
+        assert_eq!(v[..], [0, 1, 2]);
     }
 }


### PR DESCRIPTION
Using `grow` on a spilled SmallVec to the current capacity would free the backing storage when it shouldn't.

Fixes #148

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-smallvec/151)
<!-- Reviewable:end -->
