### PR TITLE
alloc is now stable

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -29,7 +29,6 @@
 //! Note that this feature requires a nightly compiler (for now).
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(not(feature = "std"), feature(alloc))]
 #![cfg_attr(feature = "union", feature(untagged_unions))]
 #![cfg_attr(feature = "specialization", feature(specialization))]
 #![cfg_attr(feature = "may_dangle", feature(dropck_eyepatch))]


### PR DESCRIPTION
The alloc crate is now stable with 1.36. That means smallvec is now no_std compatible on stable Rust.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-smallvec/159)
<!-- Reviewable:end -->
