### PR TITLE
Move use of 'default fn' to its own module

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -1253,12 +1253,7 @@ trait SpecFrom<A: Array, S> {
 }
 
 #[cfg(feature = "specialization")]
-impl<'a, A: Array> SpecFrom<A, &'a [A::Item]> for SmallVec<A> where A::Item: Clone {
-    #[inline]
-    default fn spec_from(slice: &'a [A::Item]) -> SmallVec<A> {
-        slice.into_iter().cloned().collect()
-    }
-}
+mod specialization;
 
 #[cfg(feature = "specialization")]
 impl<'a, A: Array> SpecFrom<A, &'a [A::Item]> for SmallVec<A> where A::Item: Copy {

--- a/specialization.rs
+++ b/specialization.rs
@@ -1,0 +1,16 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Implementations that require `default fn`.
+
+use super::{SpecFrom, SmallVec, Array};
+
+impl<'a, A: Array> SpecFrom<A, &'a [A::Item]> for SmallVec<A> where A::Item: Clone {
+    #[inline]
+    default fn spec_from(slice: &'a [A::Item]) -> SmallVec<A> {
+        slice.into_iter().cloned().collect()
+    }
+}


### PR DESCRIPTION
This is the proper way to do `cfg(...)` gating when dealing with an unstable feature that introduces syntax.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-smallvec/161)
<!-- Reviewable:end -->
