### PR TITLE
Deprecate unreachable function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - 1.20.0
+  - 1.36.0
   - nightly
   - beta
   - stable

--- a/lib.rs
+++ b/lib.rs
@@ -54,6 +54,7 @@ use std::borrow::{Borrow, BorrowMut};
 use std::cmp;
 use std::fmt;
 use std::hash::{Hash, Hasher};
+use std::hint::unreachable_unchecked;
 use std::iter::{IntoIterator, FromIterator, repeat};
 use std::mem;
 use std::mem::ManuallyDrop;
@@ -130,12 +131,11 @@ macro_rules! smallvec {
 /// Hint to the optimizer that any code path which calls this function is
 /// statically unreachable and can be removed.
 ///
-/// Equivalent to `std::hint::unreachable_unchecked` but works in older versions of Rust.
+/// Equivalent to `std::hint::unreachable_unchecked`.
 #[inline]
+#[deprecated(note = "Use std::hint::unreachable_unchecked instead")]
 pub unsafe fn unreachable() -> ! {
-    enum Void {}
-    let x: &Void = mem::transmute(1usize);
-    match *x {}
+    unreachable_unchecked()
 }
 
 /// `panic!()` in debug builds, optimization hint in release.
@@ -144,7 +144,7 @@ macro_rules! debug_unreachable {
     () => { debug_unreachable!("entered unreachable code") };
     ($e:expr) => {
         if cfg!(not(debug_assertions)) {
-            unreachable();
+            unreachable_unchecked();
         } else {
             panic!($e);
         }
@@ -768,7 +768,7 @@ impl<A: Array> SmallVec<A> {
     pub fn swap_remove(&mut self, index: usize) -> A::Item {
         let len = self.len();
         self.swap(len - 1, index);
-        self.pop().unwrap_or_else(|| unsafe { unreachable() })
+        self.pop().unwrap_or_else(|| unsafe { unreachable_unchecked() })
     }
 
     /// Remove all elements from the vector.


### PR DESCRIPTION
This is designed to merged after #162, as it deprecates a function that should be no longer necessary on newer Rust versions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-smallvec/164)
<!-- Reviewable:end -->
