### PR TITLE
Use SliceIndex trait for SmallVec's Index trait

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - 1.20.0
+  - 1.36.0
   - nightly
   - beta
   - stable

--- a/lib.rs
+++ b/lib.rs
@@ -60,6 +60,7 @@ use std::mem::ManuallyDrop;
 use std::ops;
 use std::ptr;
 use std::slice;
+use std::slice::SliceIndex;
 #[cfg(feature = "std")]
 use std::io;
 #[cfg(feature = "serde")]
@@ -1291,30 +1292,19 @@ impl<A: Array> From<A> for SmallVec<A> {
     }
 }
 
-macro_rules! impl_index {
-    ($index_type: ty, $output_type: ty) => {
-        impl<A: Array> ops::Index<$index_type> for SmallVec<A> {
-            type Output = $output_type;
-            #[inline]
-            fn index(&self, index: $index_type) -> &$output_type {
-                &(&**self)[index]
-            }
-        }
+impl<A: Array, I: SliceIndex<[A::Item]>> ops::Index<I> for SmallVec<A> {
+    type Output = I::Output;
 
-        impl<A: Array> ops::IndexMut<$index_type> for SmallVec<A> {
-            #[inline]
-            fn index_mut(&mut self, index: $index_type) -> &mut $output_type {
-                &mut (&mut **self)[index]
-            }
-        }
+    fn index(&self, index: I) -> &I::Output {
+        &(**self)[index]
     }
 }
 
-impl_index!(usize, A::Item);
-impl_index!(ops::Range<usize>, [A::Item]);
-impl_index!(ops::RangeFrom<usize>, [A::Item]);
-impl_index!(ops::RangeTo<usize>, [A::Item]);
-impl_index!(ops::RangeFull, [A::Item]);
+impl<A: Array, I: SliceIndex<[A::Item]>> ops::IndexMut<I> for SmallVec<A> {
+    fn index_mut(&mut self, index: I) -> &mut I::Output {
+        &mut (&mut **self)[index]
+    }
+}
 
 impl<A: Array> ExtendFromSlice<A::Item> for SmallVec<A> where A::Item: Copy {
     fn extend_from_slice(&mut self, other: &[A::Item]) {


### PR DESCRIPTION
Requires Rust 1.28.0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-smallvec/166)
<!-- Reviewable:end -->
