### PR TITLE
Use no_std by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,8 @@ readme = "README.md"
 documentation = "https://doc.servo.org/smallvec/"
 
 [features]
-std = []
+write = []
 union = []
-default = ["std"]
 specialization = []
 may_dangle = []
 


### PR DESCRIPTION
Since `alloc` became stable, the `std` feature is only needed to enable `impl Write for SmallVec`, which most users of this crate do not need.  This patch replaces the enabled-by-default `std` feature with a disabled-by-default `write` feature.  This decreases the chance that users of this crate will accidentally depend on libstd when they don't need it.