### PR TITLE
Version 1.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smallvec"
-version = "0.6.10"
+version = "1.0.0"
 edition = "2018"
 authors = ["Simon Sapin <simon.sapin@exyr.org>"]
 license = "MIT/Apache-2.0"


### PR DESCRIPTION
* Requires Rust 1.36 or later.
* [breaking change] Use `MaybeUninit` to avoid possible undefined behavior (#162, #170).
* [breaking change] The `drain` method now takes a range argument, just like the standard `Vec::drain` (#145).
* [breaking change] Remove the `unreachable` function and replace it with the new standard `unreachable_unchecked` function (#164).
* [breaking change] Use `no_std` by default. This crate depends only on `core` and `alloc` by default. If the optional `write` feature is enabled then it depends on `std` so that `SmallVec<[u8;_]>` can implement the `std::io::Write` trait (#173).
* Add support for 96-element small vectors, `SmallVec<[T; 96]>` (#163).
* Iterators now implement `FusedIterator` (#172).
* Indexing now uses the standard `SliceIndex` trait (#166).
* Remove the deprecated `VecLike` trait (#165).
* Use `NonNull` internally (#171).
* Add automatic fuzz testing and MIRI testing (#168, #162).
* Update syntax and formatting to Rust 2018 standard (#174, #167).