### PR TITLE
Implement into_boxed_slice() and doc-comment it.

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -37,6 +37,7 @@ extern crate alloc;
 #[cfg(any(test, feature = "write"))]
 extern crate std;
 
+use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::borrow::{Borrow, BorrowMut};
 use core::cmp;
@@ -891,6 +892,14 @@ impl<A: Array> SmallVec<A> {
         } else {
             self.into_iter().collect()
         }
+    }
+
+    /// Converts a `SmallVec` into a `Box<[T]>` without reallocating if the `SmallVec` has already spilled
+    /// onto the heap.
+    ///
+    /// Note that this will drop any excess capacity.
+    pub fn into_boxed_slice(self) -> Box<[A::Item]> {
+        self.into_vec().into_boxed_slice()
     }
 
     /// Convert the SmallVec into an `A` if possible. Otherwise return `Err(Self)`.


### PR DESCRIPTION
Implements `into_boxed_slice()` as per suggestion in #184.

I didn't write tests, since all I did was to call an existing method of `SmallVec`, `into_vec()` to create a `Vec` from it and then call a method of `alloc::vec::Vec`, `into_boxed_slice()` on the resulting `Vec`. Thus, nothing in my code needs testing, since it is trivially offloading to other methods.

I didn't, however, find a test exercising `into_vec()`, however. That is maybe something I can do? If so, can I get some pointers to where I should look for example tests and where my tests should live?

EDIT: Never mind, I forgot that unit tests are in the same file, so I scrutinized smallvec_ops.rs to search for a test for `into_vec()` and couldn't find it.