### PR TITLE
Version 1.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smallvec"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2018"
 authors = ["Simon Sapin <simon.sapin@exyr.org>"]
 license = "MIT/Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -6,3 +6,21 @@ rust-smallvec
 [Release notes](https://github.com/servo/rust-smallvec/releases)
 
 "Small vector" optimization for Rust: store up to a small number of items on the stack
+
+## Example
+
+```rust
+use smallvec::{SmallVec, smallvec};
+    
+// This SmallVec can hold up to 4 items on the stack:
+let mut v: SmallVec<[i32; 4]> = smallvec![1, 2, 3, 4];
+
+// It will automatically move its contents to the heap if
+// contains more than four items:
+v.push(5);
+
+// SmallVec points to a slice, so you can use normal slice
+// indexing and other methods to access its contents:
+v[0] = v[1] + v[2];
+v.sort();
+```


### PR DESCRIPTION
Changes in this release:

* Added new method `SmallVec::into_boxed_slice` (#190).
* Added new methods `IntoIter::as_slice` and `as_mut_slice` (#182).
* `IntoIter` now implements `Clone` (#192).
* Improved documentation and testing (#186, #189).
* Minor code cleanups (#176).

Also added a simple example to the README.