### PR TITLE
Add support for constant generics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ readme = "README.md"
 documentation = "https://docs.rs/smallvec/"
 
 [features]
+const_generics = []
 write = []
 union = []
 specialization = []

--- a/lib.rs
+++ b/lib.rs
@@ -29,6 +29,8 @@
 #![cfg_attr(feature = "union", feature(untagged_unions))]
 #![cfg_attr(feature = "specialization", feature(specialization))]
 #![cfg_attr(feature = "may_dangle", feature(dropck_eyepatch))]
+#![cfg_attr(feature = "const_generics", allow(incomplete_features))]
+#![cfg_attr(feature = "const_generics", feature(const_generics))]
 #![deny(missing_docs)]
 
 #[doc(hidden)]
@@ -1667,6 +1669,13 @@ impl<'a> Drop for SetLenOnDrop<'a> {
     }
 }
 
+#[cfg(feature = "const_generics")]
+unsafe impl<T, const N: usize> Array for [T; N] {
+    type Item = T;
+    fn size() -> usize { N }
+}
+
+#[cfg(not(feature = "const_generics"))]
 macro_rules! impl_array(
     ($($size:expr),+) => {
         $(
@@ -1678,6 +1687,7 @@ macro_rules! impl_array(
     }
 );
 
+#[cfg(not(feature = "const_generics"))]
 impl_array!(
     0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 20, 24, 32, 36, 0x40, 0x60, 0x80,
     0x100, 0x200, 0x400, 0x600, 0x800, 0x1000, 0x2000, 0x4000, 0x6000, 0x8000, 0x10000, 0x20000,
@@ -2532,5 +2542,11 @@ mod tests {
         v.grow(4);
         assert_eq!(v.capacity(), 4);
         assert_eq!(v[..], [0, 1, 2]);
+    }
+
+    #[cfg(feature = "const_generics")]
+    #[test]
+    fn const_generics() {
+        let _v = SmallVec::<[i32; 987]>::default();
     }
 }


### PR DESCRIPTION
No breaking changes and no internal hacks. This PR only adds a feature to switch between implementations of the `Array` trait.

I personally think that this approach is pretty reasonable and should be at least considered for discussion.