### PR TITLE
Fix CI

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -14,7 +14,7 @@ honggfuzz_fuzz = ["honggfuzz"]
 
 
 [dependencies]
-honggfuzz = { version = "0.5.45", optional = true }
+honggfuzz = { version = "0.5.47", optional = true }
 afl = { version = "0.4", optional = true }
 smallvec = { path = ".." }
 

--- a/fuzz/travis-fuzz.sh
+++ b/fuzz/travis-fuzz.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-cargo install --force honggfuzz
+cargo install --force honggfuzz --version 0.5.47
 for TARGET in fuzz_targets/*; do
     FILENAME=$(basename $TARGET)
 	FILE="${FILENAME%.*}"


### PR DESCRIPTION
Pin `cargo install honggfuzz` version to match the same version of `Cargo.toml`