### PR TITLE
Add #[inline] attribute to all fns which return SmallVec

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -1055,6 +1055,7 @@ impl<A: Array> SmallVec<A> {
     ///         assert_eq!(&*rebuilt, &[4, 5, 6]);
     ///     }
     /// }
+    #[inline]
     pub unsafe fn from_raw_parts(ptr: *mut A::Item, length: usize, capacity: usize) -> SmallVec<A> {
         assert!(capacity > A::size());
         SmallVec {
@@ -1372,6 +1373,7 @@ where
 }
 
 impl<A: Array> FromIterator<A::Item> for SmallVec<A> {
+    #[inline]
     fn from_iter<I: IntoIterator<Item = A::Item>>(iterable: I) -> SmallVec<A> {
         let mut v = SmallVec::new();
         v.extend(iterable);
@@ -1452,6 +1454,7 @@ impl<A: Array> Clone for SmallVec<A>
 where
     A::Item: Clone,
 {
+    #[inline]
     fn clone(&self) -> SmallVec<A> {
         let mut new_vector = SmallVec::with_capacity(self.len());
         for element in self.iter() {
@@ -1700,6 +1703,7 @@ trait ToSmallVec<A:Array> {
 
 impl<A:Array> ToSmallVec<A> for [A::Item]
     where A::Item: Copy {
+    #[inline]
     fn to_smallvec(&self) -> SmallVec<A> {
         SmallVec::from_slice(self)
     }


### PR DESCRIPTION
When rustc fails to inline a `SmallVec` constructor, it can carry a significant performance cost: for example, if `SmallVec::<[i64; 128]>::from_iter(...)` fails to inline, it will perform an unnecessary 1kb memcpy.

I've recently been bitten by this when using `SmallVec` in a context where rustc seemed to be reluctant to perform inlining (a large fn with nested closures). Switching from `SmallVec::from_iter` to `SmallVec::new` and `push`, with a buffer size of 256 bytes, saved over 20ns per call. For larger buffers, `from_iter` carried a proportionally higher cost, even when the actual capacity in use didn't change.