### PR TITLE
Deprecate and hide ExtendFromSlice trait

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,4 +1,5 @@
 #![feature(test)]
+#![allow(deprecated)]
 
 #[macro_use]
 extern crate smallvec;

--- a/lib.rs
+++ b/lib.rs
@@ -189,11 +189,14 @@ macro_rules! debug_unreachable {
 /// initialize(&mut small_vec);
 /// assert_eq!(&small_vec as &[_], b"Test!");
 /// ```
+#[doc(hidden)]
+#[deprecated]
 pub trait ExtendFromSlice<T> {
     /// Extends a collection from a slice of its element type
     fn extend_from_slice(&mut self, other: &[T]);
 }
 
+#[allow(deprecated)]
 impl<T: Clone> ExtendFromSlice<T> for Vec<T> {
     fn extend_from_slice(&mut self, other: &[T]) {
         Vec::extend_from_slice(self, other)
@@ -1397,6 +1400,7 @@ impl<A: Array, I: SliceIndex<[A::Item]>> ops::IndexMut<I> for SmallVec<A> {
     }
 }
 
+#[allow(deprecated)]
 impl<A: Array> ExtendFromSlice<A::Item> for SmallVec<A>
 where
     A::Item: Copy,


### PR DESCRIPTION
This trait is only needed for internal benchmarking and should not have been public.  It will be removed in version 2.0.