### PR TITLE
Make sure smallvec! is usable without being in scope

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -145,7 +145,7 @@ macro_rules! smallvec {
         $crate::SmallVec::from_elem($elem, $n)
     });
     ($($x:expr),*$(,)*) => ({
-        let count = 0usize $(+ smallvec!(@one $x))*;
+        let count = 0usize $(+ $crate::smallvec!(@one $x))*;
         let mut vec = $crate::SmallVec::new();
         if count <= vec.inline_size() {
             $(vec.push($x);)*

--- a/tests/macro.rs
+++ b/tests/macro.rs
@@ -1,0 +1,25 @@
+/// This file tests `smallvec!` without actually having the macro in scope.
+/// This forces any recursion to use a `$crate` prefix to reliably find itself.
+
+#[test]
+fn smallvec() {
+    let mut vec: smallvec::SmallVec<[i32; 2]>;
+
+    macro_rules! check {
+        ($init:tt) => {
+            vec = smallvec::smallvec! $init;
+            assert_eq!(*vec, *vec! $init);
+        }
+    }
+
+    check!([0; 0]);
+    check!([1; 1]);
+    check!([2; 2]);
+    check!([3; 3]);
+
+    check!([]);
+    check!([1]);
+    check!([1, 2]);
+    check!([1, 2, 3]);
+}
+


### PR DESCRIPTION
Macro recursion should use a `$crate` prefix to reliably find itself.