### PR TITLE
Update and document serde support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ name = "smallvec"
 path = "lib.rs"
 
 [dependencies]
-serde = { version = "1", optional = true }
+serde = { version = "1", optional = true, default-features = false }
 
 [dev_dependencies]
 bincode = "1.0.1"

--- a/lib.rs
+++ b/lib.rs
@@ -16,6 +16,11 @@
 //!
 //! ## Optional features
 //!
+//! ### `serde`
+//!
+//! When this optional dependency is enabled, `SmallVec` implements the `serde::Serialize` and
+//! `serde::Deserialize` traits.
+//!
 //! ### `write`
 //!
 //! When this feature is enabled, `SmallVec<[u8; _]>` implements the `std::io::Write` trait.


### PR DESCRIPTION
* Document the optional 'serde' feature. Fixes #224.
* Disable unused serde features. This makes serde support compatible with `no_std`.