### PR TITLE
Don’t heap-allocate for zero-size items

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smallvec"
-version = "1.4.0"
+version = "1.4.1"
 edition = "2018"
 authors = ["Simon Sapin <simon.sapin@exyr.org>"]
 license = "MIT/Apache-2.0"


### PR DESCRIPTION
Allocating zero bytes is Undefined Behavior.
CC https://github.com/servo/servo/pull/26304#issuecomment-653626058