### PR TITLE
Version 1.4.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "smallvec"
-version = "1.4.1"
+version = "1.4.2"
 edition = "2018"
-authors = ["Simon Sapin <simon.sapin@exyr.org>"]
+authors = ["The Servo Project Developers"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/servo/rust-smallvec"
 description = "'Small vector' optimization: store up to a small number of items on the stack"


### PR DESCRIPTION
Changelog:

* `insert_many` no longer leaks elements if the provided iterator panics (#213).
* The unstable `const_generics` and `specialization` features are updated to work with the most recent nightly Rust toolchain (#232).
* Internal code cleanup (#229, #231).

This PR also changes the `author` field in `Cargo.toml` to "The Servo Project Developers".