### PR TITLE
Return allocation error in deserialize instead of panicking

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -233,6 +233,12 @@ pub enum CollectionAllocErr {
     },
 }
 
+impl fmt::Display for CollectionAllocErr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Allocation error: {:?}", self)
+    }
+}
+
 impl From<LayoutErr> for CollectionAllocErr {
     fn from(_: LayoutErr) -> Self {
         CollectionAllocErr::CapacityOverflow
@@ -1543,8 +1549,10 @@ where
     where
         B: SeqAccess<'de>,
     {
+        use serde::de::Error;
         let len = seq.size_hint().unwrap_or(0);
-        let mut values = SmallVec::with_capacity(len);
+        let mut values = SmallVec::new();
+        values.try_reserve(len).map_err(B::Error::custom)?;
 
         while let Some(value) = seq.next_element()? {
             values.push(value);


### PR DESCRIPTION
There's no way to catch allocation errors since out of memory errors
cause an abort. Fail gracefully by returning the error instead of
panicking.

I happened upon this error when deserializing untrusted data with bincode. Bincode provides a byte limit bound but for sequences it's not possible to enforce this through serde since collection types like smallvec handle their own allocation. 