### PR TITLE
Version 1.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smallvec"
-version = "1.4.2"
+version = "1.5.0"
 edition = "2018"
 authors = ["The Servo Project Developers"]
 license = "MIT/Apache-2.0"


### PR DESCRIPTION
Change log:

* Add the `append` method (#237).
* Add support for more array sizes between 17 and 31 (#234).
* Don't panic on deserialization errors (#238).