### PR TITLE
Remove extraneous branch from push

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -753,13 +753,15 @@ impl<A: Array> SmallVec<A> {
     #[inline]
     pub fn push(&mut self, value: A::Item) {
         unsafe {
-            let (_, &mut len, cap) = self.triple_mut();
-            if len == cap {
+            let (mut ptr, mut len, cap) = self.triple_mut();
+            if *len == cap {
                 self.reserve(1);
+                let &mut (heap_ptr, ref mut heap_len) = self.data.heap_mut();
+                ptr = heap_ptr;
+                len = heap_len;
             }
-            let (ptr, len_ptr, _) = self.triple_mut();
-            *len_ptr = len + 1;
-            ptr::write(ptr.add(len), value);
+            ptr::write(ptr.add(*len), value);
+            *len += 1;
         }
     }
 


### PR DESCRIPTION
`push` does two branches on the "smallness" of the `smallvec`: one before the reserve check and one after. LLVM doesn't seem to optimize the second branch away for the (very common) non-growing case. In addition, in the growing branch we know the memory will be on the heap, so no need to branch here.

On my machine, this improves `bench_push` from approx 300ns to 263ns (+/- 5 on both).