### PR TITLE
Remove `min_const_generics` feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,6 @@
 #![cfg_attr(feature = "specialization", allow(incomplete_features))]
 #![cfg_attr(feature = "specialization", feature(specialization))]
 #![cfg_attr(feature = "may_dangle", feature(dropck_eyepatch))]
-#![cfg_attr(feature = "const_generics", feature(min_const_generics))]
 #![deny(missing_docs)]
 
 #[doc(hidden)]


### PR DESCRIPTION
Depends on https://github.com/rust-lang/rust/pull/79135.

If #240 is already under development and will be available before the 1.50 release, then feel free to close this PR. Otherwise, the feature removal will benefit upstream projects in the meanwhile.