### PR TITLE
Version 1.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ script: |
   cargo test --verbose &&
   cargo test --verbose --features serde &&
   ([ $TRAVIS_RUST_VERSION != nightly ] || cargo check --verbose --no-default-features) &&
-  ([ $TRAVIS_RUST_VERSION != nightly ] || cargo test --verbose --features union) &&
+  ([ $TRAVIS_RUST_VERSION != beta ] || cargo test --verbose --features union) &&
   ([ $TRAVIS_RUST_VERSION != nightly ] || cargo test --verbose --all-features) &&
   ([ $TRAVIS_RUST_VERSION != nightly ] || cargo bench --verbose bench) &&
   ([ $TRAVIS_RUST_VERSION != nightly ] || bash ./scripts/run_miri.sh) &&

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smallvec"
-version = "1.5.1"
+version = "1.6.0"
 edition = "2018"
 authors = ["The Servo Project Developers"]
 license = "MIT/Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@
 //!
 //! ### `union`
 //!
-//! **This feature requires Rust 1.50.**
+//! **This feature requires Rust 1.49.**
 //!
 //! When the `union` feature is enabled `smallvec` will track its state (inline or spilled)
 //! without the use of an enum tag, reducing the size of the `smallvec` by one machine word.
@@ -37,7 +37,7 @@
 //! machine words.
 //!
 //! To use this feature add `features = ["union"]` in the `smallvec` section of Cargo.toml.
-//! Note that this feature requires Rust 1.50.
+//! Note that this feature requires Rust 1.49.
 //!
 //! Tracking issue: [rust-lang/rust#55149](https://github.com/rust-lang/rust/issues/55149)
 //!


### PR DESCRIPTION
Release notes:

* The `union` feature is now compatible with stable Rust 1.49 (#248, #247).
* Fixed warnings when compiling with Rust 1.51 nightly (#242, #246).