### PR TITLE
Test for drains that shift the tail, when inline

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -111,6 +111,13 @@ fn drain() {
     assert_eq!(v.drain(1..).collect::<Vec<_>>(), &[4, 5]);
     // drain should not change the capacity
     assert_eq!(v.capacity(), old_capacity);
+
+    // Exercise the tail-shifting code when in the inline state
+    // This has the potential to produce UB due to aliasing
+    let mut v: SmallVec<[u8; 2]> = SmallVec::new();
+    v.push(1);
+    v.push(2);
+    assert_eq!(v.drain(..1).collect::<Vec<_>>(), &[1]);
 }
 
 #[test]


### PR DESCRIPTION
Previously, the test suite only had one trip through the tail-shifting
code in Drain::drop, and that is in the heap state.
In the current implementation, a tail-shifting drain while in the inline
state produces potentially dangerous aliasing which is currently
accepted by default Miri and rejected with -Ztrack-raw-pointers.

Adding this test case ensures that if this ever becomes an actual
problem it will be easy to find.