### PR TITLE
Add support for arbitrary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ may_dangle = []
 
 [dependencies]
 serde = { version = "1", optional = true, default-features = false }
+arbitrary = { version = "1", optional = true }
 
 [dev_dependencies]
 bincode = "1.0.1"

--- a/src/arbitrary.rs
+++ b/src/arbitrary.rs
@@ -1,0 +1,19 @@
+use crate::{Array, SmallVec};
+use arbitrary::{Arbitrary, Unstructured};
+
+impl<'a, A: Array> Arbitrary<'a> for SmallVec<A>
+where
+    <A as Array>::Item: Arbitrary<'a>,
+{
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        u.arbitrary_iter()?.collect()
+    }
+
+    fn arbitrary_take_rest(u: Unstructured<'a>) -> arbitrary::Result<Self> {
+        u.arbitrary_take_rest_iter()?.collect()
+    }
+
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        arbitrary::size_hint::and(<usize as Arbitrary>::size_hint(depth), (0, None))
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1651,6 +1651,9 @@ trait SpecFrom<A: Array, S> {
 #[cfg(feature = "specialization")]
 mod specialization;
 
+#[cfg(feature = "arbitrary")]
+mod arbitrary;
+
 #[cfg(feature = "specialization")]
 impl<'a, A: Array> SpecFrom<A, &'a [A::Item]> for SmallVec<A>
 where


### PR DESCRIPTION
This PR adds optional support for [Arbitrary](https://github.com/rust-fuzz/arbitrary/), which is helpful in fuzz testing. The implementation is nearly identical to Arbitrary's existing Vec implementation.