### PR TITLE
Fix all problems encounted with Miri -Ztag-raw-pointers

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,6 +61,8 @@ jobs:
       - name: miri
         if: matrix.toolchain == 'nightly'
         run: bash ./scripts/run_miri.sh
+        env:
+          MIRIFLAGS: '-Zmiri-tag-raw-pointers'
 
       - name: fuzz
         if: env.DO_FUZZ == '1'


### PR DESCRIPTION
I poked at this crate with `-Zmiri-tag-raw-pointers` before, and I was unable to fix what I found (I just added a test case that ruled out one of my wrong ideas https://github.com/servo/rust-smallvec/pull/271). I tried again just now and I guess I just understand better this time.

This PR fixes 3 separate pointer invalidation problems, which are detected by running `MIRIFLAGS=-Zmiri-tag-raw-pointers cargo miri test`.

Depending on how you squint, 2 or 3 of these are https://github.com/rust-lang/unsafe-code-guidelines/issues/133. The last one is _probably_ still present even with late invalidation, because `set_len` does a write through a `&mut`.

It's unclear to me if any of these things that Miri complains about are potentially a miscompilation in rustc due to the use of LLVM `noalias`. But perhaps given how subtle this codebase is overall, it would be best to run the tools on their pickiest settings, even if there are a few things more like a false positive than a real problem.