### PR TITLE
Add retain_mut method (as an alias to retain)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1232,6 +1232,15 @@ impl<A: Array> SmallVec<A> {
         self.truncate(len - del);
     }
 
+    /// Retains only the elements specified by the predicate.
+    ///
+    /// This method is identical in behaviour to [`retain`]; it is included only
+    /// to maintain api-compatability with `std::Vec`, where the methods are
+    /// separate for historical reasons.
+    pub fn retain_mut<F: FnMut(&mut A::Item) -> bool>(&mut self, f: F) {
+        self.retain(f)
+    }
+
     /// Removes consecutive duplicate elements.
     pub fn dedup(&mut self)
     where


### PR DESCRIPTION
Opening this speculatively, since it's ultimately less work than opening an issue?


I was trying to use this crate as a drop-in replacement for std::Vec, where I am using the retain_mut method. I understand that it isn't a useful distinction here, and I'm not sure if api compatibility is a goal, so if this doesn't make sense for the project I understand. :)
