### PR TITLE
Fix broken CI yaml script

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,7 @@ jobs:
     strategy:
       matrix:
         toolchain: ["stable", "beta", "nightly", "1.36.0"]
+        os: [ubuntu-latest]
         include:
           - toolchain: stable
             env:


### PR DESCRIPTION
The previous commit updated the CI yaml script to include the `os` key to the matrix for test jobs but did not set an initial value.

Update the matrix to test on `ubuntu-latest` by default.