### PR TITLE
Mark Array::size() as #[inline]

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2089,6 +2089,7 @@ impl<T, const N: usize> SmallVec<[T; N]> {
 #[cfg_attr(docsrs, doc(cfg(feature = "const_generics")))]
 unsafe impl<T, const N: usize> Array for [T; N] {
     type Item = T;
+    #[inline]
     fn size() -> usize {
         N
     }
@@ -2100,6 +2101,7 @@ macro_rules! impl_array(
         $(
             unsafe impl<T> Array for [T; $size] {
                 type Item = T;
+                #[inline]
                 fn size() -> usize { $size }
             }
         )+


### PR DESCRIPTION
`Array::size()` is a trivial function -- in fact, it always returns a constant. Mark it as `#[inline]` so it is instantiated in each CGU, and can be optimized without relying on crate-local LTO. See https://github.com/rust-lang/rust/issues/102539 for context.

It looks like SmallVec already marks pretty much all other trivial functions as `#[inline]`, so this seems like an oversight.