### PR TITLE
Add Bincode 2 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ debugger_visualizer = []
 [dependencies]
 serde = { version = "1", optional = true, default-features = false }
 arbitrary = { version = "1", optional = true }
+bincode2 = { package = "bincode", version = "2.0.0-rc", optional = true, default-features = false }
 
 [dev_dependencies]
 bincode = "1.0.1"

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -983,3 +983,27 @@ fn test_clone_from() {
     b.clone_from(&c);
     assert_eq!(&*b, &[20, 21, 22]);
 }
+
+#[cfg(feature = "bincode2")]
+#[test]
+fn test_bincode2() {
+    let config = bincode2::config::standard();
+    let mut small_vec: SmallVec<[i32; 2]> = SmallVec::new();
+    let mut buffer = [0u8; 128];
+    small_vec.push(1);
+    let bytes_written = bincode2::encode_into_slice(&small_vec, &mut buffer, config).unwrap();
+    let (decoded, bytes_read) =
+        bincode2::decode_from_slice::<SmallVec<[i32; 2]>, _>(&buffer, config).unwrap();
+    assert_eq!(bytes_written, bytes_read);
+    assert_eq!(small_vec, decoded);
+    small_vec.push(2);
+    // Spill the vec
+    small_vec.push(3);
+    small_vec.push(4);
+    // Check again after spilling.
+    let bytes_written = bincode2::encode_into_slice(&small_vec, &mut buffer, config).unwrap();
+    let (decoded, bytes_read) =
+        bincode2::decode_from_slice::<SmallVec<[i32; 2]>, _>(&buffer, config).unwrap();
+    assert_eq!(bytes_written, bytes_read);
+    assert_eq!(small_vec, decoded);
+}


### PR DESCRIPTION
Bincode 2.0 will include its own traits for encoding and decoding, which are more efficient than going via serde.

I opened https://github.com/bincode-org/bincode/pull/612 to add implementations for smallvec, however the recommendation there is that these traits should be implemented in the smallvec crate instead.  This PR adds a new feature `bincode2`, which, when enabled, adds implementations of the new bincode traits for `SmallVec`.

I see a roughly 10% improvement in my benchmarks when using the new bincode traits directly vs using serde, so this would be a useful feature to have.

Because there is already a dev-dependency on Bincode 1 used in tests, I've called this feature `bincode2`.  That can be changed if you'd prefer the feature to be called `bincode`.