### PR TITLE
Use `NonNull` pointer in heap version

### DIFF
--- a/debug_metadata/smallvec.natvis
+++ b/debug_metadata/smallvec.natvis
@@ -1,13 +1,14 @@
 <AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
   <Type Name="smallvec::SmallVec&lt;array$&lt;*,*&gt;&gt;" Priority="Medium">
-    <Intrinsic Name="is_inline" Expression="$T2 &gt; capacity" />
-    <Intrinsic Name="len" Expression="is_inline() ? capacity : data.variant1.value.__0.__1" />
-    <Intrinsic Name="data_ptr" Expression="is_inline() ? data.variant0.value.__0.value.value : data.variant1.value.__0.__0" />
+    <Intrinsic Name="is_inline" Expression="$T2 &gt;= capacity" />
+    <Intrinsic Name="len" Expression="is_inline() ? capacity : data.variant1.value.len" />
+    <Intrinsic Name="data_ptr" Expression="is_inline() ? data.variant0.value.__0.value.value : data.variant1.value.ptr.pointer" />
 
-    <DisplayString>{{ len={len()} }}</DisplayString>
+    <DisplayString>{{ len={len()} is_inline={is_inline()} }}</DisplayString>
     <Expand>
         <Item Name="[capacity]">is_inline() ? $T2 : capacity</Item>
         <Item Name="[len]">len()</Item>
+        <Item Name="[data_ptr]">data_ptr()</Item>
 
         <ArrayItems>
             <Size>len()</Size>
@@ -17,11 +18,10 @@
   </Type>
 
   <Type Name="smallvec::SmallVec&lt;array$&lt;*,*&gt;&gt;" Priority="MediumLow">
-    <Intrinsic Name="is_inline" Expression="$T2 &gt; capacity" />
+    <Intrinsic Name="is_inline" Expression="$T2 &gt;= capacity" />
     <Intrinsic Name="len" Expression="is_inline() ? capacity : data.heap.__1" />
-    <Intrinsic Name="data_ptr" Expression="is_inline() ? data.inline.value.value.value : data.heap.__0" />
-
-    <DisplayString>{{ len={len()} }}</DisplayString>
+    <Intrinsic Name="data_ptr" Expression="is_inline() ? data.inline.value.value.value : data.heap.__0.pointer" />
+    <DisplayString>{{ len={len()} is_inline={is_inline()} }}</DisplayString>
     <Expand>
         <Item Name="[capacity]">is_inline() ? $T2 : capacity</Item>
         <Item Name="[len]">len()</Item>

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -983,3 +983,9 @@ fn test_clone_from() {
     b.clone_from(&c);
     assert_eq!(&*b, &[20, 21, 22]);
 }
+
+#[test]
+fn test_size() {
+    use core::mem::size_of;
+    assert_eq!(24, size_of::<SmallVec<[u8; 8]>>());
+}

--- a/tests/debugger_visualizer.rs
+++ b/tests/debugger_visualizer.rs
@@ -19,14 +19,14 @@ g
 dx sv
 "#,
     expected_statements = r#"
-sv               : { len=0x2 } [Type: smallvec::SmallVec<array$<i32,4> >]
+sv               : { len=0x2 is_inline=true } [Type: smallvec::SmallVec<array$<i32,4> >]
     [<Raw View>]     [Type: smallvec::SmallVec<array$<i32,4> >]
     [capacity]       : 4
     [len]            : 0x2 [Type: unsigned __int64]
     [0]              : 1 [Type: int]
     [1]              : 2 [Type: int]
 
-sv               : { len=0x5 } [Type: smallvec::SmallVec<array$<i32,4> >]
+sv               : { len=0x5 is_inline=false } [Type: smallvec::SmallVec<array$<i32,4> >]
     [<Raw View>]     [Type: smallvec::SmallVec<array$<i32,4> >]
     [capacity]       : 0x8 [Type: unsigned __int64]
     [len]            : 0x5 [Type: unsigned __int64]
@@ -36,7 +36,7 @@ sv               : { len=0x5 } [Type: smallvec::SmallVec<array$<i32,4> >]
     [3]              : 4 [Type: int]
     [4]              : 5 [Type: int]
 
-sv               : { len=0x5 } [Type: smallvec::SmallVec<array$<i32,4> >]
+sv               : { len=0x5 is_inline=false } [Type: smallvec::SmallVec<array$<i32,4> >]
     [<Raw View>]     [Type: smallvec::SmallVec<array$<i32,4> >]
     [capacity]       : 0x8 [Type: unsigned __int64]
     [len]            : 0x5 [Type: unsigned __int64]


### PR DESCRIPTION
Since `SmallVec` allocate on heap only if capacity is larger than inner capacity and therefore larger than 1, it cannot be null. Also, this is same behaviour as `std::vec::Vec` which always uses non-null pointer, which is dangling if it has zero capacity.

This change reduces size of enum in some cases because it can exploit [niche optimization](https://rust-lang.github.io/unsafe-code-guidelines/glossary.html#niche). For example, `size_of::<SmallVec<[u8; 8]>>` is 24 bytes with changes from this PR while before it was 32 bytes.

Also:
1. Changed some internal APIs to indicate that we work with non-nullable pointers.
2. Updated natvis and fixed bug with incorrect calculation of `is_inline` intrinsic.