### PR TITLE
ci: Update toolchain action.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,11 +35,9 @@ jobs:
         run: sudo apt-get update -y && sudo apt-get install -y binutils-dev libunwind8-dev libcurl4-openssl-dev libelf-dev libdw-dev cmake gcc libiberty-dev
 
       - name: Install toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: ${{ matrix.toolchain }}
-          override: true
 
       - name: Cargo build
         run: cargo build --verbose


### PR DESCRIPTION
The `actions-rs` actions haven't been maintained in some time and trigger a number of warnings about use of deprecated functionality.