### PR TITLE
Annotate SmallVec::insert_from_slice with `#[inline]`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1758,6 +1758,7 @@ where
     /// elements toward the back.
     ///
     /// For slices of `Copy` types, this is more efficient than `insert`.
+    #[inline]
     pub fn insert_from_slice(&mut self, index: usize, slice: &[A::Item]) {
         self.reserve(slice.len());
 


### PR DESCRIPTION
This resolves the code size regression I observed in https://github.com/servo/rust-smallvec/pull/298#issuecomment-1683063333.

It reduces the ICU4X tiny wasm file test from 20472 B to 19168 B.

Thoughts?

CC @Manishearth @robertbastian