### PR TITLE
Micro-optimize push() and insert().

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 edition = "2018"
 authors = ["The Servo Project Developers"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
This helps with some micro-benchmarks in Firefox where we end up pushing thousands of elements to a SmallVec.

See https://treeherder.mozilla.org/perfherder/comparesubtest?originalProject=try&newProject=try&newRevision=78b672e152c65fbacd3f0bccc4bd069b177addd6&originalSignature=4765498&newSignature=4765498&framework=1&application=firefox&originalRevision=6f0164143af00325c9f15e7c6387d8f9c7993daf&page=1&showOnlyConfident=1