### PR TITLE
Fix `no_std` build, add to CI. (v2)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,11 +64,25 @@ jobs:
         working-directory: fuzz
         run: ./travis_fuzz.sh
 
+  no-std:
+    name: no_std
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          target: thumbv7m-none-eabi
+      - name: Cargo build
+        run: cargo build --verbose
+
   build_result:
     name: homu build finished
     runs-on: ubuntu-latest
     needs:
       - "linux-ci"
+      - "no-std"
 
     steps:
       - name: Mark the job as successful

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@
 #[doc(hidden)]
 pub extern crate alloc;
 
-// #[cfg(any(test, feature = "write"))]
+#[cfg(any(test, feature = "write"))]
 extern crate std;
 
 #[cfg(test)]


### PR DESCRIPTION
This had been broken in b0e296024403d0daf7f7f1658a26f573f838f8ac.