### PR TITLE
fix: don't special-case `doc` for `feature = "const_generics"`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2386,7 +2386,7 @@ impl<T, const N: usize> SmallVec<[T; N]> {
     }
 }
 
-#[cfg(all(feature = "const_generics", not(doc)))]
+#[cfg(feature = "const_generics")]
 #[cfg_attr(docsrs, doc(cfg(feature = "const_generics")))]
 unsafe impl<T, const N: usize> Array for [T; N] {
     type Item = T;
@@ -2396,7 +2396,7 @@ unsafe impl<T, const N: usize> Array for [T; N] {
     }
 }
 
-#[cfg(any(not(feature = "const_generics"), doc))]
+#[cfg(not(feature = "const_generics"))]
 macro_rules! impl_array(
     ($($size:expr),+) => {
         $(
@@ -2409,7 +2409,7 @@ macro_rules! impl_array(
     }
 );
 
-#[cfg(any(not(feature = "const_generics"), doc))]
+#[cfg(not(feature = "const_generics"))]
 impl_array!(
     0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
     26, 27, 28, 29, 30, 31, 32, 36, 0x40, 0x60, 0x80, 0x100, 0x200, 0x400, 0x600, 0x800, 0x1000,


### PR DESCRIPTION
The following invocations all succeed now:

```console
cargo doc
cargo +nightly doc
cargo doc --features const_generics
cargo +nightly doc --features const_generics
```

Closes https://github.com/servo/rust-smallvec/issues/327