### PR TITLE
Correctly handle `Vec` with zero capacity in `from_vec`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,16 +15,14 @@ jobs:
         toolchain: ["stable", "beta", "nightly", "1.57.0"]
         include:
           - toolchain: stable
-            env:
-              DO_FUZZ: 1
+            fuzz: 1
           - toolchain: beta
-            env:
-              DO_FUZZ: 1
+            fuzz: 1
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install packages
-        if: matrix.os == 'ubuntu-latest'
+      - name: Install packages for fuzzing
+        if: runner.os == 'Linux' && matrix.fuzz == 1
         run: sudo apt-get update -y && sudo apt-get install -y binutils-dev libunwind8-dev libcurl4-openssl-dev libelf-dev libdw-dev cmake gcc libiberty-dev
 
       - name: Install toolchain
@@ -60,9 +58,9 @@ jobs:
           MIRIFLAGS: '-Zmiri-tag-raw-pointers'
 
       - name: fuzz
-        if: env.DO_FUZZ == '1'
+        if: matrix.fuzz == 1
         working-directory: fuzz
-        run: ./travis_fuzz.sh
+        run: ./travis-fuzz.sh
 
   no-std:
     name: no_std

--- a/fuzz/travis-fuzz.sh
+++ b/fuzz/travis-fuzz.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-cargo install --force honggfuzz --version 0.5.47
+cargo install --force honggfuzz --version "^0.5.47"
 for TARGET in fuzz_targets/*; do
     FILENAME=$(basename $TARGET)
 	FILE="${FILENAME%.*}"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -524,6 +524,10 @@ impl<T, const N: usize> SmallVec<T, N> {
 
     #[inline]
     pub fn from_vec(vec: Vec<T>) -> Self {
+        if vec.capacity() == 0 {
+            return Self::new();
+        }
+
         if Self::is_zst() {
             // "Move" elements to stack buffer. They're ZST so we don't actually have to do
             // anything. Just make sure they're not dropped.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -718,6 +718,13 @@ fn shrink_to_fit_unspill() {
 }
 
 #[test]
+fn shrink_after_from_empty_vec() {
+    let mut v = SmallVec::<u8, 2>::from_vec(vec![]);
+    v.shrink_to_fit();
+    assert!(!v.spilled())
+}
+
+#[test]
 fn test_into_vec() {
     let vec = SmallVec::<u8, 2>::from_iter(0..2);
     assert_eq!(vec.into_vec(), vec![0, 1]);


### PR DESCRIPTION
Since the standard library does  not allocate any memory for vectors with capacity 0, the pointer returned by `as_mut_ptr` is dangling in that case. This causes a segfault, when `shrink_to_fit` tries to free.