### PR TITLE
Impl get_size::GetSize (behind feature flag) (v1 branch)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ debugger_visualizer = []
 [dependencies]
 serde = { version = "1", optional = true, default-features = false }
 arbitrary = { version = "1", optional = true }
+get-size = { version = "0.1", optional = true, default-features = false }
 
 [dev_dependencies]
 bincode = "1.0.1"

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1023,3 +1023,70 @@ fn drain_keep_rest() {
 
     assert_eq!(a, SmallVec::<[i32; 3]>::from_slice(&[1i32, 3, 5, 6, 7, 8]));
 }
+
+#[cfg(all(feature = "get-size", target_pointer_width = "64"))]
+mod get_size {
+    use super::*;
+
+    #[test]
+    fn end_to_end1() {
+        use ::get_size::GetSize;
+
+        let mut a: SmallVec<[i32; 2]> = smallvec![];
+        assert!(!a.spilled());
+        assert_eq!(a.len(), 0);
+        assert_eq!(a.get_size(), 24);
+        assert_eq!(a.get_heap_size(), 0);
+
+        a.push(0);
+        assert_eq!(a.len(), 1);
+        assert!(!a.spilled());
+        assert_eq!(a.get_size(), 24);
+        assert_eq!(a.get_heap_size(), 0);
+
+        a.push(1);
+        assert_eq!(a.len(), 2);
+        assert!(!a.spilled());
+        assert_eq!(a.get_size(), 24);
+        assert_eq!(a.get_heap_size(), 0);
+
+        a.push(2);
+        assert_eq!(a.len(), 3);
+        assert!(a.spilled());
+        assert_eq!(a.get_size(), 40);
+        assert_eq!(a.get_heap_size(), 16);
+
+        a.push(3);
+        assert_eq!(a.len(), 4);
+        assert!(a.spilled());
+        assert_eq!(a.get_size(), 40);
+        assert_eq!(a.get_heap_size(), 16);
+
+        a.push(4);
+        assert_eq!(a.len(), 5);
+        assert!(a.spilled());
+        assert_eq!(a.get_size(), 56);
+        assert_eq!(a.get_heap_size(), 32);
+
+    }
+
+    #[cfg(not(feature = "union"))]
+    #[test]
+    fn stack_size_no_union1() {
+        use ::get_size::GetSize;
+
+        assert_eq!(SmallVec::<[i32; 2]>::get_stack_size(), 24);
+        assert_eq!(SmallVec::<[i32; 10]>::get_stack_size(), 56);
+    }
+
+    #[cfg(feature="union")]
+    #[test]
+    fn stack_size_union1() {
+        use ::get_size::GetSize;
+
+        assert_eq!(SmallVec::<[i32; 2]>::get_stack_size(), 24);
+        assert_eq!(SmallVec::<[i32; 10]>::get_stack_size(), 48);
+    }
+
+}
+


### PR DESCRIPTION
Shows memory usage of the struct

cf. issue #331

This includes unittests, and I have briefly used this in real programmes successfully.