### PR TITLE
Impl get_size::GetSize (behind feature flag) (v2 branch)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ drain_keep_rest = ["drain_filter"]
 
 [dependencies]
 serde = { version = "1", optional = true, default-features = false }
+get-size = { version = "0.1", optional = true, default-features = false }
 
 [dev_dependencies]
 bincode = "1.0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,10 @@
 //! [Rustonomicon](https://doc.rust-lang.org/1.42.0/nomicon/dropck.html#an-escape-hatch).
 //!
 //! Tracking issue: [rust-lang/rust#34761](https://github.com/rust-lang/rust/issues/34761)
+//!
+//! ### `get-size`
+//!
+//! When this optional dependency is enabled, `SmallVec` implements the `get_size::GetSize` trait.
 
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]
@@ -88,6 +92,8 @@ use serde::{
 };
 #[cfg(feature = "write")]
 use std::io;
+#[cfg(feature = "get-size")]
+use get_size::GetSize;
 
 /// Error type for APIs with fallible heap allocation
 #[derive(Debug)]
@@ -2174,5 +2180,24 @@ impl<const N: usize> io::Write for SmallVec<u8, N> {
     #[inline]
     fn flush(&mut self) -> io::Result<()> {
         Ok(())
+    }
+}
+
+#[cfg(feature = "get-size")]
+impl<T, const N: usize> GetSize for SmallVec<T, N>
+where
+    T: GetSize,
+{
+    fn get_heap_size(&self) -> usize {
+        let mut total = 0;
+        if self.spilled() {
+            total += self.capacity() * T::get_stack_size();
+        }
+
+        for v in self.iter() {
+            total += v.get_heap_size();
+        }
+
+        total
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1028,3 +1028,49 @@ fn drain_keep_rest() {
 
     assert_eq!(a, SmallVec::<i32, 3>::from_slice(&[1i32, 3, 5, 6, 7, 8]));
 }
+
+#[cfg(all(feature = "get-size", target_pointer_width = "64"))]
+#[test]
+fn get_size_end_to_end1() {
+    use ::get_size::GetSize;
+
+    assert_eq!(SmallVec::<i32, 2>::get_stack_size(), 24);
+    assert_eq!(SmallVec::<i32, 10>::get_stack_size(), 48);
+
+    let mut a: SmallVec<i32, 2> = smallvec![];
+    assert!(!a.spilled());
+    assert_eq!(a.len(), 0);
+    assert_eq!(a.get_size(), 24);
+    assert_eq!(a.get_heap_size(), 0);
+
+    a.push(0);
+    assert_eq!(a.len(), 1);
+    assert!(!a.spilled());
+    assert_eq!(a.get_size(), 24);
+    assert_eq!(a.get_heap_size(), 0);
+
+    a.push(1);
+    assert_eq!(a.len(), 2);
+    assert!(!a.spilled());
+    assert_eq!(a.get_size(), 24);
+    assert_eq!(a.get_heap_size(), 0);
+
+    a.push(2);
+    assert_eq!(a.len(), 3);
+    assert!(a.spilled());
+    assert_eq!(a.get_size(), 40);
+    assert_eq!(a.get_heap_size(), 16);
+
+    a.push(3);
+    assert_eq!(a.len(), 4);
+    assert!(a.spilled());
+    assert_eq!(a.get_size(), 40);
+    assert_eq!(a.get_heap_size(), 16);
+
+    a.push(4);
+    assert_eq!(a.len(), 5);
+    assert!(a.spilled());
+    assert_eq!(a.get_size(), 56);
+    assert_eq!(a.get_heap_size(), 32);
+
+}


### PR DESCRIPTION
Shows memory usage of the struct

cf. issue #331

this is against the `v2` branch. The tests pass, but I haven't tried this code in real uses yet.