### PR TITLE
Implement `Hash` trait for `SmallVec`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,8 @@ use alloc::alloc::Layout;
 use core::borrow::Borrow;
 use core::borrow::BorrowMut;
 use core::fmt::Debug;
+use core::hash::{Hash, Hasher};
+use core::marker::PhantomData;
 use core::mem::align_of;
 use core::mem::size_of;
 use core::mem::ManuallyDrop;
@@ -78,8 +80,6 @@ use core::ptr::addr_of_mut;
 use core::ptr::copy;
 use core::ptr::copy_nonoverlapping;
 use core::ptr::NonNull;
-
-use core::marker::PhantomData;
 
 #[cfg(feature = "serde")]
 use serde::{
@@ -2046,6 +2046,12 @@ where
     #[inline]
     fn cmp(&self, other: &SmallVec<T, N>) -> core::cmp::Ordering {
         self.as_slice().cmp(other.as_slice())
+    }
+}
+
+impl<T: Hash, const N: usize> Hash for SmallVec<T, N> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.as_slice().hash(state)
     }
 }
 


### PR DESCRIPTION
While calling the `hash` function on a `SmallVec` currently works via dereferencing into `&[T]` (see `test_hash` on `tests.rs`), this is not enough to allow deriving `Hash` on e.g. a struct containing a single field of type `SmallVec`.

I ran into this issue while upgrading one of my crates to the `beta.2` release.