### PR TITLE
Implement `From<[T; M]> for SmallVec<T, N>` for all `M, N` (v2)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1909,12 +1909,12 @@ impl<'a, T: Clone, const N: usize> From<&'a [T]> for SmallVec<T, N> {
         slice.iter().cloned().collect()
     }
 }
-impl<T: Clone, const N: usize> From<[T; N]> for SmallVec<T, N> {
+impl<T, const N: usize> From<[T; N]> for SmallVec<T, N> {
     fn from(array: [T; N]) -> Self {
         Self::from_buf(array)
     }
 }
-impl<T: Clone, const N: usize> From<Vec<T>> for SmallVec<T, N> {
+impl<T, const N: usize> From<Vec<T>> for SmallVec<T, N> {
     fn from(array: Vec<T>) -> Self {
         Self::from_vec(array)
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -656,6 +656,16 @@ fn test_from() {
     let small_vec: SmallVec<NoClone, 1> = SmallVec::from(vec);
     assert_eq!(&*small_vec, &[NoClone(42)]);
     drop(small_vec);
+
+    let array = [1; 128];
+    let small_vec: SmallVec<u8, 1> = SmallVec::from(array);
+    assert_eq!(&*small_vec, vec![1; 128].as_slice());
+    drop(small_vec);
+
+    let array = [99];
+    let small_vec: SmallVec<u8, 128> = SmallVec::from(array);
+    assert_eq!(&*small_vec, &[99u8]);
+    drop(small_vec);
 }
 
 #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -644,6 +644,18 @@ fn test_from() {
     let small_vec: SmallVec<u8, 128> = SmallVec::from(array);
     assert_eq!(&*small_vec, vec![99u8; 128].as_slice());
     drop(small_vec);
+
+    #[derive(PartialEq, Eq, Debug)]
+    struct NoClone(u8);
+    let array = [NoClone(42)];
+    let small_vec: SmallVec<NoClone, 1> = SmallVec::from(array);
+    assert_eq!(&*small_vec, &[NoClone(42)]);
+    drop(small_vec);
+
+    let vec = vec![NoClone(42)];
+    let small_vec: SmallVec<NoClone, 1> = SmallVec::from(vec);
+    assert_eq!(&*small_vec, &[NoClone(42)]);
+    drop(small_vec);
 }
 
 #[test]


### PR DESCRIPTION
(First commit removes the unnecessary `T: Clone` bound from `From<array>` and `From<Vec>` impls that weren't there in v1.)

Allow using `SmallVec::from(array)` and `array.into()` like you can with `Vec`, even when `array.len() != SmallVec::inline_capacity()`. If the source length is longer than the smallvec's inline capacity, it will use heap-allocation, otherwise it will use inline capacity.

<details> <summary> const-eval limitations </summary>

Ideally, the implementation would be as below to explicitly optimize for the three different cases even in debug mode, but it doesn't work because `[T; M]` and `[T; N]` are still considered different types.

```rs
if M > N {
  Self::from_vec(Vec::from(array))
} else if M == N {
  Self::from_buf(array) // error: expected `N`, found `M`
} else {
  // same as PR
}
```

However, with `opt-level >= 1`, Rust appears to reliably compile this PR to either a basically just memcpy (for M <= N) or an alloc and a memcpy (for M > N).

</details>

Backported to v2 as #339