### PR TITLE
Implement `From<A2> for SmallVec<A1>` for all `A2, A1` with the same `Item`  (v1)

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -623,6 +623,16 @@ fn test_from() {
     let small_vec: SmallVec<[u8; 128]> = SmallVec::from(array);
     assert_eq!(&*small_vec, vec![99u8; 128].as_slice());
     drop(small_vec);
+
+    let array = [1; 128];
+    let small_vec: SmallVec<[u8; 1]> = SmallVec::from(array);
+    assert_eq!(&*small_vec, vec![1; 128].as_slice());
+    drop(small_vec);
+
+    let array = [99];
+    let small_vec: SmallVec<[u8; 128]> = SmallVec::from(array);
+    assert_eq!(&*small_vec, &[99u8]);
+    drop(small_vec);
 }
 
 #[test]


### PR DESCRIPTION
#338 backported to v1

With `opt-level >= 1`, Rust appears to reliably compile this PR to either a basically just memcpy (for M <= N) or an alloc and a memcpy (for M > N)

Resolves #272