### PR TITLE
Make README example work

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ rust-smallvec
 use smallvec::{SmallVec, smallvec};
     
 // This SmallVec can hold up to 4 items on the stack:
-let mut v: SmallVec<i32, 4> = smallvec![1, 2, 3, 4];
+let mut v: SmallVec<[i32; 4]> = smallvec![1, 2, 3, 4];
 
 // It will automatically move its contents to the heap if
 // contains more than four items:


### PR DESCRIPTION
It never was updated to follow the signature change. Fixes servo/rust-smallvec#342.

Hypothetically one could want the README to follow the v1 version of SmallVec still. Seems unlikely.