### PR TITLE
bugfix for append not set self.len properly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1000,6 +1000,7 @@ impl<T, const N: usize> SmallVec<T, N> {
         // SAFETY: we have a mutable reference to each vector and each uniquely owns its memory.
         // so the ranges can't overlap
         unsafe { copy_nonoverlapping(other.as_ptr(), ptr, other_len) };
+        unsafe { self.set_len(total_len) }
     }
 
     #[inline]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -328,6 +328,25 @@ fn test_insert_many() {
     );
 }
 
+#[test]
+fn test_append() {
+    let mut v: SmallVec<u8, 8> = SmallVec::new();
+    for x in 0..4 {
+        v.push(x);
+    }
+    assert_eq!(v.len(), 4);
+
+    let mut n: SmallVec<u8, 2> = SmallVec::from_buf([5, 6]);
+    v.append(&mut n);
+    assert_eq!(v.len(), 6);
+    assert_eq!(n.len(), 0);
+
+    assert_eq!(
+        &v.iter().map(|v| *v).collect::<Vec<_>>(),
+        &[0, 1, 2, 3, 5, 6]
+    );
+}
+
 struct MockHintIter<T: Iterator> {
     x: T,
     hint: usize,


### PR DESCRIPTION
`append` currently not properly `set_len` for self.

This patch fix it.