### PR TITLE
Make `RawSmallVec` (and its fields) public only under `feature = "internals"`. (v2)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ std = []
 specialization = []
 may_dangle = []
 serde = ["dep:serde_core"]
+internals = []
 
 [dependencies]
 bytes = { version = "1", optional = true, default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,7 +120,7 @@ impl core::fmt::Display for CollectionAllocErr {
 /// niche-optimization can be performed and the type is covariant
 /// with respect to `T`.
 #[repr(C)]
-pub union RawSmallVec<T, const N: usize> {
+union RawSmallVec<T, const N: usize> {
     inline: ManuallyDrop<MaybeUninit<[T; N]>>,
     heap: (NonNull<T>, usize),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,17 +114,25 @@ impl core::fmt::Display for CollectionAllocErr {
 
 impl core::error::Error for CollectionAllocErr {}
 
-/// Either a stack array with `length <= N` or a heap array
-/// whose pointer and capacity are stored here.
-///
-/// We store a `NonNull<T>` instead of a `*mut T`, so that
-/// niche-optimization can be performed and the type is covariant
-/// with respect to `T`.
-#[repr(C)]
-pub union RawSmallVec<T, const N: usize> {
-    inline: ManuallyDrop<MaybeUninit<[T; N]>>,
-    heap: (NonNull<T>, usize),
+mod raw {
+    use super::{ManuallyDrop, MaybeUninit, NonNull};
+
+    /// Either a stack array with `length <= N` or a heap array
+    /// whose pointer and capacity are stored here.
+    ///
+    /// We store a `NonNull<T>` instead of a `*mut T` so that type is covariant
+    /// with respect to `T`, and since the heap pointer is never null.
+    #[repr(C)]
+    pub union RawSmallVec<T, const N: usize> {
+        pub inline: ManuallyDrop<MaybeUninit<[T; N]>>,
+        pub heap: (NonNull<T>, usize),
+    }
 }
+
+#[cfg(feature = "internals")]
+pub use raw::RawSmallVec;
+#[cfg(not(feature = "internals"))]
+use raw::RawSmallVec;
 
 #[inline]
 fn infallible<T>(result: Result<T, CollectionAllocErr>) -> T {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,7 @@ pub extern crate alloc;
 #[cfg(any(test, feature = "std"))]
 extern crate std;
 
+mod rawsmallvec;
 #[cfg(test)]
 mod tests;
 
@@ -95,6 +96,11 @@ use serde_core::{
 #[cfg(feature = "std")]
 use std::io;
 
+#[cfg(feature = "internals")]
+pub use rawsmallvec::RawSmallVec;
+#[cfg(not(feature = "internals"))]
+use rawsmallvec::RawSmallVec;
+
 /// Error type for APIs with fallible heap allocation
 #[derive(Debug)]
 pub enum CollectionAllocErr {
@@ -113,26 +119,6 @@ impl core::fmt::Display for CollectionAllocErr {
 }
 
 impl core::error::Error for CollectionAllocErr {}
-
-mod raw {
-    use super::{ManuallyDrop, MaybeUninit, NonNull};
-
-    /// Either a stack array with `length <= N` or a heap array
-    /// whose pointer and capacity are stored here.
-    ///
-    /// We store a `NonNull<T>` instead of a `*mut T` so that type is covariant
-    /// with respect to `T`, and since the heap pointer is never null.
-    #[repr(C)]
-    pub union RawSmallVec<T, const N: usize> {
-        pub inline: ManuallyDrop<MaybeUninit<[T; N]>>,
-        pub heap: (NonNull<T>, usize),
-    }
-}
-
-#[cfg(feature = "internals")]
-pub use raw::RawSmallVec;
-#[cfg(not(feature = "internals"))]
-use raw::RawSmallVec;
 
 #[inline]
 fn infallible<T>(result: Result<T, CollectionAllocErr>) -> T {

--- a/src/rawsmallvec.rs
+++ b/src/rawsmallvec.rs
@@ -1,0 +1,13 @@
+use core::mem::{ManuallyDrop, MaybeUninit};
+use core::ptr::NonNull;
+
+/// Either a stack array with `length <= N` or a heap array
+/// whose pointer and capacity are stored here.
+///
+/// We store a `NonNull<T>` instead of a `*mut T` so that type is covariant
+/// with respect to `T`, and since the heap pointer is never null.
+#[repr(C)]
+pub union RawSmallVec<T, const N: usize> {
+    pub inline: ManuallyDrop<MaybeUninit<[T; N]>>,
+    pub heap: (NonNull<T>, usize),
+}


### PR DESCRIPTION
It doesn't have any [public API](https://docs.rs/smallvec/2.0.0-alpha.7/smallvec/union.RawSmallVec.html) other than auto traits and blanket impls, and no other public APIs take or return it, so it probably doesn't need to be public.

(Alternately, it's fields could be maked `pub` so external users could use it for their own purposes, but it would probably be better for them to just define their own version.)