### PR TITLE
Fix test `test_hash`

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,5 +1,6 @@
 use crate::{smallvec, SmallVec};
 
+use core::hash::Hasher;
 use core::iter::FromIterator;
 
 use alloc::borrow::ToOwned;
@@ -600,19 +601,24 @@ fn test_hash() {
     use std::collections::hash_map::DefaultHasher;
     use std::hash::Hash;
 
+    fn hash(value: impl Hash) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        value.hash(&mut hasher);
+        hasher.finish()
+    }
+
     {
         let mut a: SmallVec<u32, 2> = SmallVec::new();
         let b = [1, 2];
         a.extend(b.iter().cloned());
-        let mut hasher = DefaultHasher::new();
-        assert_eq!(a.hash(&mut hasher), b.hash(&mut hasher));
+        assert_eq!(hash(a), hash(b));
     }
+
     {
         let mut a: SmallVec<u32, 2> = SmallVec::new();
         let b = [1, 2, 11, 12];
         a.extend(b.iter().cloned());
-        let mut hasher = DefaultHasher::new();
-        assert_eq!(a.hash(&mut hasher), b.hash(&mut hasher));
+        assert_eq!(hash(a), hash(b));
     }
 }
 


### PR DESCRIPTION
Compline fails on my machine (Clippy is on). And I found the test implement for `Hash` is incorrect. 

[`x.hash()` returns a `()` instead of an u32](https://doc.rust-lang.org/std/hash/trait.Hash.html). So the test is meaningless. It will always succeed.

 I write a pitch using a function `hash()` to compute a hash value :)

```
error: `assert_eq` of unit values detected. This will always succeed
   --> src/tests.rs:608:9
    |
608 |         assert_eq!(a.hash(&mut hasher), b.hash(&mut hasher));
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unit_cmp
    = note: `#[deny(clippy::unit_cmp)]` on by default
```