### PR TITLE
Added test for servo#353 and fixed use after free bug that causes it

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -961,10 +961,11 @@ impl<T, const N: usize> SmallVec<T, N> {
         // SAFETY: see above
         debug_assert!(self.spilled());
         let len = self.len();
-        let (ptr, cap) = self.raw.heap;
+        let cap = self.raw.heap.1;
         if len == cap {
             self.reserve(1);
         }
+        let ptr = self.raw.heap.0;
         ptr.as_ptr().add(len).write(value);
         self.set_len(len + 1)
     }


### PR DESCRIPTION
I took a look at what was causing #353.

Turns out the `push_heap` function was placing the heap pointer into a local variable before calling `self.reserve()`. reserve in turn calls `realloc()` - which can free the old heap allocation & create a new one. When this happens, the old `ptr` is becomes invalid. 

The code was writing to this invalid pointer (`ptr.as_ptr().add(len).write(value)`) - which is a use-after-free bug.

This PR fixes the bug and adds a regression test.