### PR TITLE
Add PartialEq impls to mirror the stdlib

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2020,6 +2020,56 @@ where
 }
 impl<T, const N: usize> Eq for SmallVec<T, N> where T: Eq {}
 
+impl<T, U, const N: usize, const M: usize> PartialEq<[U; M]> for SmallVec<T, N>
+where
+    T: PartialEq<U>,
+{
+    #[inline]
+    fn eq(&self, other: &[U; M]) -> bool {
+        self[..] == other[..]
+    }
+}
+
+impl<T, U, const N: usize, const M: usize> PartialEq<&[U; M]> for SmallVec<T, N>
+where
+    T: PartialEq<U>,
+{
+    #[inline]
+    fn eq(&self, other: &&[U; M]) -> bool {
+        self[..] == other[..]
+    }
+}
+
+impl<T, U, const N: usize> PartialEq<[U]> for SmallVec<T, N>
+where
+    T: PartialEq<U>,
+{
+    #[inline]
+    fn eq(&self, other: &[U]) -> bool {
+        self[..] == other[..]
+    }
+}
+
+impl<T, U, const N: usize> PartialEq<&[U]> for SmallVec<T, N>
+where
+    T: PartialEq<U>,
+{
+    #[inline]
+    fn eq(&self, other: &&[U]) -> bool {
+        self[..] == other[..]
+    }
+}
+
+impl<T, U, const N: usize> PartialEq<&mut [U]> for SmallVec<T, N>
+where
+    T: PartialEq<U>,
+{
+    #[inline]
+    fn eq(&self, other: &&mut [U]) -> bool {
+        self[..] == other[..]
+    }
+}
+
 impl<T, const N: usize> PartialOrd for SmallVec<T, N>
 where
     T: PartialOrd,


### PR DESCRIPTION
Copied from https://doc.rust-lang.org/1.80.0/src/alloc/vec/partial_eq.rs.html#7