### PR TITLE
[v2] Update to Rust 2021 Edition.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "smallvec"
 version = "2.0.0-alpha.7"
-edition = "2018"
+edition = "2021"
 rust-version = "1.57"
 authors = ["The Servo Project Developers"]
 license = "MIT OR Apache-2.0"
@@ -21,7 +21,7 @@ extract_if = []
 [dependencies]
 serde = { version = "1", optional = true, default-features = false }
 
-[dev_dependencies]
+[dev-dependencies]
 bincode = "1.0.1"
 
 [package.metadata.docs.rs]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -2,7 +2,7 @@
 name = "smallvec-fuzz"
 version = "0.1.0"
 authors = ["Dawid Ciężarkiewicz <dpc@dpc.pw>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 [package.metadata]


### PR DESCRIPTION
`smallvec` v2's MSRV is currently 1.57.0, which is after the release of Edition 2021 in Rust 1.56.0.

(Also applies a change to `Cargo.toml` changing the deprecated `dev_dependencies` to the preferred `dev-dependencies`, which `cargo fix --edition` warned about but won't actually be an error until Edition _2024_.)