### PR TITLE
Implement `MallocSizeOf` for SmallVec (v2)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Cargo test w/ serde
         run: cargo test --verbose --features serde
 
+      - name: Cargo test w/ malloc_size_of
+        run: cargo test --verbose --features malloc_size_of
+
       - name: Cargo check w/o default features
         if: matrix.toolchain == 'nightly'
         run: cargo check --verbose --no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ extract_if = []
 
 [dependencies]
 serde = { version = "1", optional = true, default-features = false }
-malloc_size_of = { version = "0.1", optional = true, default-features = false }
+malloc_size_of = { version = "0.1.1", optional = true, default-features = false }
 
 [dev-dependencies]
 bincode = "1.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ extract_if = []
 
 [dependencies]
 serde = { version = "1", optional = true, default-features = false }
+malloc_size_of = { version = "0.1", optional = true, default-features = false }
 
 [dev-dependencies]
 bincode = "1.0.1"


### PR DESCRIPTION
Now that [malloc_size_of](https://github.com/servo/malloc_size_of) is published to crates.io we are moving the trait implementations of [MallocSizeOf](https://docs.rs/malloc_size_of/latest/malloc_size_of/trait.MallocSizeOf.html) and related traits into the crates that define the types. This will avoid the situation where depending on `malloc_size_of` pulls in a large number of dependencies.

This PR adds the implementation of `MallocSizeOf` to the 2.x version of the `smallvec` crate.