### PR TITLE
feat: impl `bytes::BufMut` for `SmallVec` (v2)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ may_dangle = []
 extract_if = []
 
 [dependencies]
+bytes = { version = "1", optional = true, default-features = false }
 serde = { version = "1", optional = true, default-features = false }
 malloc_size_of = { version = "0.1.1", optional = true, default-features = false }
 


### PR DESCRIPTION
The [`bytes`](https://crates.io/crates/bytes) crate is a popular crate for manipulating bytes efficiently. Implementing the `BufMut` trait for `SmallVec` would allow it to serve as a seamless replacement for `Vec<u8>` when working with `bytes`.