### PR TITLE
Implement bincode2 encode/decode support for smallvec v1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,9 +17,9 @@ jobs:
         os: [ubuntu-latest]
         include:
           - toolchain: stable
-            fuzz: 1
+            fuzz: 0
           - toolchain: beta
-            fuzz: 1
+            fuzz: 0
           - os: windows-latest
             toolchain: nightly
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ specialization = []
 may_dangle = []
 drain_filter = []
 drain_keep_rest = ["drain_filter"]
+impl_bincode = ["bincode", "unty"]
 
 # UNSTABLE FEATURES (requires Rust nightly)
 # Enable to use the #[debugger_visualizer] attribute.
@@ -29,6 +30,8 @@ debugger_visualizer = []
 serde = { version = "1", optional = true, default-features = false }
 malloc_size_of = { version = "0.1", optional = true, default-features = false }
 arbitrary = { version = "1", optional = true }
+bincode = { version = "2", optional = true, default-features = false }
+unty = { version = "0.0.4", optional = true, default-features = false }
 
 [dev-dependencies]
 bincode1 = { package = "bincode", version = "1.0.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ malloc_size_of = { version = "0.1", optional = true, default-features = false }
 arbitrary = { version = "1", optional = true }
 
 [dev-dependencies]
-bincode = "1.0.1"
+bincode1 = { package = "bincode", version = "1.0.1" }
 debugger_test = "0.1.0"
 debugger_test_parser = "0.1.0"
 

--- a/fuzz/travis-fuzz.sh
+++ b/fuzz/travis-fuzz.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-cargo install --force honggfuzz --version "^0.5.47"
+cargo install --force honggfuzz --version 0.5.47
 for TARGET in fuzz_targets/*; do
     FILENAME=$(basename $TARGET)
 	FILE="${FILENAME%.*}"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2498,3 +2498,106 @@ impl<T> Clone for ConstNonNull<T> {
 }
 
 impl<T> Copy for ConstNonNull<T> {}
+
+#[cfg(feature = "impl_bincode")]
+use bincode::{
+    de::{BorrowDecoder, Decode, Decoder, read::Reader},
+    enc::{Encode, Encoder, write::Writer},
+    error::{DecodeError, EncodeError},
+    BorrowDecode,
+};
+
+#[cfg(feature = "impl_bincode")]
+impl<A, Context> Decode<Context> for SmallVec<A>
+where
+    A: Array,
+    A::Item: Decode<Context>,
+{
+    fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
+        use core::convert::TryInto;
+        let len = u64::decode(decoder)?;
+        let len = len.try_into().map_err(|_| DecodeError::OutsideUsizeRange(len))?;
+        decoder.claim_container_read::<A::Item>(len)?;
+
+        let mut vec = SmallVec::with_capacity(len);
+        if unty::type_equal::<A::Item, u8>() {
+            // Initialize the smallvec's buffer.  Note that we need to do this through
+            // the raw pointer as we cannot name the type [u8; N] even though A::Item is u8.
+            let ptr = vec.as_mut_ptr();
+            // SAFETY: A::Item is u8 and the smallvec has been allocated with enough capacity
+            unsafe {
+                core::ptr::write_bytes(ptr, 0, len);
+                vec.set_len(len);
+            }
+            // Read the data into the smallvec's buffer.
+            let slice = vec.as_mut_slice();
+            // SAFETY: A::Item is u8
+            let slice = unsafe { core::mem::transmute::<&mut [A::Item], &mut [u8]>(slice) };
+            decoder.reader().read(slice)?;
+        } else {
+            for _ in 0..len {
+                decoder.unclaim_bytes_read(core::mem::size_of::<A::Item>());
+                vec.push(A::Item::decode(decoder)?);
+            }
+        }
+        Ok(vec)
+    }
+}
+
+#[cfg(feature = "impl_bincode")]
+impl<'de, A, Context> BorrowDecode<'de, Context> for SmallVec<A>
+where
+    A: Array,
+    A::Item: BorrowDecode<'de, Context>,
+{
+    fn borrow_decode<D: BorrowDecoder<'de, Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
+        use core::convert::TryInto;
+        let len = u64::decode(decoder)?;
+        let len = len.try_into().map_err(|_| DecodeError::OutsideUsizeRange(len))?;
+        decoder.claim_container_read::<A::Item>(len)?;
+
+        let mut vec = SmallVec::with_capacity(len);
+        if unty::type_equal::<A::Item, u8>() {
+            // Initialize the smallvec's buffer.  Note that we need to do this through
+            // the raw pointer as we cannot name the type [u8; N] even though A::Item is u8.
+            let ptr = vec.as_mut_ptr();
+            // SAFETY: A::Item is u8 and the smallvec has been allocated with enough capacity
+            unsafe {
+                core::ptr::write_bytes(ptr, 0, len);
+                vec.set_len(len);
+            }
+            // Read the data into the smallvec's buffer.
+            let slice = vec.as_mut_slice();
+            // SAFETY: A::Item is u8
+            let slice = unsafe { core::mem::transmute::<&mut [A::Item], &mut [u8]>(slice) };
+            decoder.reader().read(slice)?;
+        } else {
+            for _ in 0..len {
+                decoder.unclaim_bytes_read(core::mem::size_of::<A::Item>());
+                vec.push(A::Item::borrow_decode(decoder)?);
+            }
+        }
+        Ok(vec)
+    }
+}
+
+#[cfg(feature = "impl_bincode")]
+impl<A> Encode for SmallVec<A>
+where
+    A: Array,
+    A::Item: Encode,
+{
+    fn encode<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
+        (self.len() as u64).encode(encoder)?;
+        if unty::type_equal::<A::Item, u8>() {
+            // Safety: A::Item is u8
+            let slice: &[u8] = unsafe { core::mem::transmute(self.as_slice()) };
+            encoder.writer().write(slice)?;
+        } else {
+            for item in self.iter() {
+                item.encode(encoder)?;
+            }
+        }
+        Ok(())
+    }
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -835,7 +835,7 @@ fn test_write() {
 #[cfg(feature = "serde")]
 #[test]
 fn test_serde() {
-    use bincode::{config, deserialize};
+    use bincode1::{config, deserialize};
     let mut small_vec: SmallVec<[i32; 2]> = SmallVec::new();
     small_vec.push(1);
     let encoded = config().limit(100).serialize(&small_vec).unwrap();

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1072,3 +1072,65 @@ fn test_insert_out_of_bounds() {
     let mut v: SmallVec<[i32; 4]> = SmallVec::new();
     v.insert(10, 6);
 }
+
+#[cfg(feature = "impl_bincode")]
+#[test]
+fn test_bincode() {
+    let config = bincode::config::standard();
+    let mut small_vec: SmallVec<[i32; 2]> = SmallVec::new();
+    let mut buffer = [0u8; 128];
+    small_vec.push(1);
+    let bytes_written = bincode::encode_into_slice(&small_vec, &mut buffer, config).unwrap();
+    let (decoded, bytes_read) =
+        bincode::decode_from_slice::<SmallVec<[i32; 2]>, _>(&buffer, config).unwrap();
+    assert_eq!(bytes_written, bytes_read);
+    assert_eq!(small_vec, decoded);
+    let (decoded, bytes_read) =
+        bincode::borrow_decode_from_slice::<SmallVec<[i32; 2]>, _>(&buffer, config).unwrap();
+    assert_eq!(bytes_written, bytes_read);
+    assert_eq!(small_vec, decoded);
+    // Spill the vec
+    small_vec.push(2);
+    small_vec.push(3);
+    small_vec.push(4);
+    // Check again after spilling.
+    let bytes_written = bincode::encode_into_slice(&small_vec, &mut buffer, config).unwrap();
+    let (decoded, bytes_read) =
+        bincode::decode_from_slice::<SmallVec<[i32; 2]>, _>(&buffer, config).unwrap();
+    assert_eq!(bytes_written, bytes_read);
+    assert_eq!(small_vec, decoded);
+    let (decoded, bytes_read) =
+        bincode::borrow_decode_from_slice::<SmallVec<[i32; 2]>, _>(&buffer, config).unwrap();
+    assert_eq!(bytes_written, bytes_read);
+    assert_eq!(small_vec, decoded);
+}
+
+#[cfg(feature = "impl_bincode")]
+#[test]
+fn test_bincode_u8() {
+    let config = bincode::config::standard();
+    let mut small_vec: SmallVec<[u8; 16]> = SmallVec::new();
+    let mut buffer = [0u8; 128];
+    small_vec.extend_from_slice(b"testing test");
+    let bytes_written = bincode::encode_into_slice(&small_vec, &mut buffer, config).unwrap();
+    let (decoded, bytes_read) =
+        bincode::decode_from_slice::<SmallVec<[u8; 16]>, _>(&buffer, config).unwrap();
+    assert_eq!(bytes_written, bytes_read);
+    assert_eq!(small_vec, decoded);
+    let (decoded, bytes_read) =
+        bincode::borrow_decode_from_slice::<SmallVec<[u8; 16]>, _>(&buffer, config).unwrap();
+    assert_eq!(bytes_written, bytes_read);
+    assert_eq!(small_vec, decoded);
+    // Spill the vec
+    small_vec.extend_from_slice(b"some more testing");
+    // Check again after spilling.
+    let bytes_written = bincode::encode_into_slice(&small_vec, &mut buffer, config).unwrap();
+    let (decoded, bytes_read) =
+        bincode::decode_from_slice::<SmallVec<[u8; 16]>, _>(&buffer, config).unwrap();
+    assert_eq!(bytes_written, bytes_read);
+    assert_eq!(small_vec, decoded);
+    let (decoded, bytes_read) =
+        bincode::borrow_decode_from_slice::<SmallVec<[u8; 16]>, _>(&buffer, config).unwrap();
+    assert_eq!(bytes_written, bytes_read);
+    assert_eq!(small_vec, decoded);
+}


### PR DESCRIPTION
We would like to use [bincode v2](https://github.com/bincode-org/bincode) to encode some structures that contain smallvecs.  Now that bincode v2 has been released, we can add optional implementations of its traits to smallvec.

This PR implements support in smallvec v1 if the optional `impl_bincode` feature is specified.  Similarly to how bincode has optimizations for `Vec<u8>`, it includes optimizations for `SmallVec<[u8; N]>`.

Note that I have not updated the existing dev-dependency on `bincode` that is used in tests.  This is because bincode v2 has a fairly high MSRV (1.85.0).