### PR TITLE
Unconditionally implement `core::error::Error`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,9 +121,7 @@ impl core::fmt::Display for CollectionAllocErr {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for CollectionAllocErr {}
+impl core::error::Error for CollectionAllocErr {}
 
 /// Either a stack array with `length <= N` or a heap array
 /// whose pointer and capacity are stored here.


### PR DESCRIPTION
The `error_in_core` feature is stable since Rust 1.81, below this crate's MSRV.