### PR TITLE
Add missing `Vec` functionality

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -279,25 +279,6 @@ fn gen_from_elem<V: Vector<u64>>(n: usize, b: &mut Bencher) {
 }
 
 #[bench]
-fn bench_insert_many(b: &mut Bencher) {
-    #[inline(never)]
-    fn insert_many_noinline<I: IntoIterator<Item = u64>>(
-        vec: &mut SmallVec<u64, VEC_SIZE>,
-        index: usize,
-        iterable: I,
-    ) {
-        vec.insert_many(index, iterable)
-    }
-
-    b.iter(|| {
-        let mut vec = SmallVec::<u64, VEC_SIZE>::new();
-        insert_many_noinline(&mut vec, 0, 0..SPILLED_SIZE as _);
-        insert_many_noinline(&mut vec, 0, 0..SPILLED_SIZE as _);
-        vec
-    });
-}
-
-#[bench]
 fn bench_insert_from_slice(b: &mut Bencher) {
     let v: Vec<u64> = (0..SPILLED_SIZE as _).collect();
     b.iter(|| {

--- a/fuzz/fuzz_targets/smallvec_ops.rs
+++ b/fuzz/fuzz_targets/smallvec_ops.rs
@@ -94,7 +94,7 @@ fn do_test<const N: usize>(data: &[u8]) -> SmallVec<u8, N> {
                 let insert_pos = next_usize!(bytes) % (v.len() + 1);
                 let how_many = next_usize!(bytes);
                 let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                    v.insert_many(insert_pos, (0..how_many).map(|_| bytes.next().unwrap()));
+                    v.splice(insert_pos..insert_pos, (0..how_many).map(|_| bytes.next().unwrap()));
                 }));
 
                 if result.is_err() {
@@ -107,7 +107,7 @@ fn do_test<const N: usize>(data: &[u8]) -> SmallVec<u8, N> {
 
             19 => {
                 let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                    v.retain(|e| {
+                    v.retain_mut(|e| {
                         let alt_e = bytes.next().unwrap();
                         let retain = *e >= alt_e;
                         *e = e.wrapping_add(alt_e);


### PR DESCRIPTION
This will add missing `const` qualifiers, various stable functions, and some performance optimizations from `Vec` to `SmallVec`.
Among them is `splice`, which can replace uses of `insert_many`. The latter has been removed, which should fix #255.

As a small bit of refactoring, functions that rely exclusively on the global allocator (such as `with_capacity`) have been put in a separate implementation block. That will make it a bit easier to add an allocator api later on.