### PR TITLE
`extract_if` no longer requires a feature gate.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ documentation = "https://docs.rs/smallvec/"
 std = []
 specialization = []
 may_dangle = []
-extract_if = []
 
 [dependencies]
 bytes = { version = "1", optional = true, default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,13 +30,6 @@
 //! When this optional dependency is enabled, `SmallVec` implements the `serde::Serialize` and
 //! `serde::Deserialize` traits.
 //!
-//! ### `extract_if`
-//!
-//! **This feature is unstable.** It may change to match the unstable `extract_if` method in libstd.
-//!
-//! Enables the `extract_if` method, which produces an iterator that calls a user-provided
-//! closure to determine which elements of the vector to remove and yield from the iterator.
-//!
 //! ### `specialization`
 //!
 //! **This feature is unstable and requires a nightly build of the Rust toolchain.**
@@ -484,7 +477,6 @@ impl<T, const N: usize> Drain<'_, T, N> {
     }
 }
 
-#[cfg(feature = "extract_if")]
 /// An iterator which uses a closure to determine if an element should be removed.
 ///
 /// Returned from [`SmallVec::extract_if`][1].
@@ -507,7 +499,6 @@ where
     pred: F,
 }
 
-#[cfg(feature = "extract_if")]
 impl<T, const N: usize, F> core::fmt::Debug for ExtractIf<'_, T, N, F>
 where
     F: FnMut(&mut T) -> bool,
@@ -520,7 +511,6 @@ where
     }
 }
 
-#[cfg(feature = "extract_if")]
 impl<T, F, const N: usize> Iterator for ExtractIf<'_, T, N, F>
 where
     F: FnMut(&mut T) -> bool,
@@ -556,7 +546,6 @@ where
     }
 }
 
-#[cfg(feature = "extract_if")]
 impl<T, F, const N: usize> Drop for ExtractIf<'_, T, N, F>
 where
     F: FnMut(&mut T) -> bool,
@@ -1083,7 +1072,6 @@ impl<T, const N: usize> SmallVec<T, N> {
         }
     }
 
-    #[cfg(feature = "extract_if")]
     /// Creates an iterator which uses a closure to determine if element in the range should be removed.
     ///
     /// If the closure returns true, then the element is removed and yielded.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -933,7 +933,6 @@ fn test_clone_from() {
     assert_eq!(&*b, &[20, 21, 22]);
 }
 
-#[cfg(feature = "extract_if")]
 #[test]
 fn test_extract_if() {
     let mut a: SmallVec<u8, 2> = smallvec![0, 1u8, 2, 3, 4, 5, 6, 7, 8, 0];


### PR DESCRIPTION
Since the standard library version has stabilized, we don't need to worry about the API changing anymore.