### PR TITLE
Shrink code produced by `smallvec![]`.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2140,18 +2140,20 @@ impl<T: Clone, const N: usize> Clone for IntoIter<T, N> {
 macro_rules! smallvec {
     // count helper: transform any expression into 1
     (@one $x:expr) => (1usize);
+    () => (
+        $crate::SmallVec::new()
+    );
     ($elem:expr; $n:expr) => ({
         $crate::SmallVec::from_elem($elem, $n)
     });
-    ($($x:expr),*$(,)?) => ({
-        let count = 0usize $(+ $crate::smallvec!(@one $x))*;
-        #[allow(unused_mut)]
+    ($($x:expr),+$(,)?) => ({
+        let count = 0usize $(+ $crate::smallvec!(@one $x))+;
         let mut vec = $crate::SmallVec::new();
         if count <= vec.capacity() {
             $(vec.push($x);)*
             vec
         } else {
-            $crate::SmallVec::from_vec($crate::alloc::vec![$($x,)*])
+            $crate::SmallVec::from_vec($crate::alloc::vec![$($x,)+])
         }
     });
 }


### PR DESCRIPTION
Currently `smallvec![]` expands to this:
```
{
    let count = 0usize;
    #[allow(unused_mut)]
    let mut vec = ::smallvec::SmallVec::new();
    if count <= vec.capacity() {
	vec
    } else {
	::smallvec::SmallVec::from_vec(::alloc::vec::Vec::new())
    }
};
```
This commit adds a rule to the `smallvec!` macro for the zero-length case so it instead expands to this:
```
::smallvec::SmallVec::new()
```
The `std::vec!` macro already has a similar special case.

This commit also improves the non-zero case.
- It removes the `#[allow(unused_mut)]`, which was only needed for the zero-length case.
- It changes the `*` repetitions to `+`. (Again, like `std::vec`.)