### PR TITLE
Add `encase` trait implementations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ malloc_size_of = { version = "0.1", optional = true, default-features = false }
 arbitrary = { version = "1", optional = true }
 bincode = { version = "2", optional = true, default-features = false }
 unty = { version = "0.0.4", optional = true, default-features = false }
+encase = { version = "0.12", optional = true, default-features = false }
 
 [dev-dependencies]
 bincode1 = { package = "bincode", version = "1.0.1" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,6 +88,10 @@
 //! [Rustonomicon](https://doc.rust-lang.org/1.42.0/nomicon/dropck.html#an-escape-hatch).
 //!
 //! Tracking issue: [rust-lang/rust#34761](https://github.com/rust-lang/rust/issues/34761)
+//! 
+//! ### `encase`
+//!
+//! When this optional dependency is enabled, `SmallVec` implements `encase`'s traits.
 
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]
@@ -2603,3 +2607,6 @@ where
         Ok(())
     }
 }
+
+#[cfg(feature = "encase")]
+encase::rts_array::impl_rts_array!(SmallVec<A>; (T, A: Array<Item = T>); using len truncate);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1134,3 +1134,23 @@ fn test_bincode_u8() {
     assert_eq!(bytes_written, bytes_read);
     assert_eq!(small_vec, decoded);
 }
+
+#[cfg(feature = "encase")]
+#[test]
+fn test_encase() {
+    let v = SmallVec::from([1.43_f32, 4.05, 4.55]);
+
+    let mut buf = [255u8; 12];
+    let mut s_buf = encase::StorageBuffer::new(&mut buf);
+
+    s_buf.write(&v).unwrap();
+    assert_eq!(&s_buf.as_ref()[0..][..4], &v[0].to_le_bytes());
+    assert_eq!(&s_buf.as_ref()[4..][..4], &v[1].to_le_bytes());
+    assert_eq!(&s_buf.as_ref()[8..][..4], &v[2].to_le_bytes());
+
+    let mut v_out: SmallVec<[f32; 3]> = SmallVec::new();
+    s_buf.read(&mut v_out).unwrap();
+    assert_eq!(v, v_out);
+
+    assert_eq!(v, s_buf.create::<SmallVec<[f32; 3]>>().unwrap());
+}


### PR DESCRIPTION
Resolves https://github.com/servo/rust-smallvec/issues/376.