### PR TITLE
Switch `serde` dependency to `serde_core` for v2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,11 @@ std = []
 specialization = []
 may_dangle = []
 extract_if = []
+serde = ["dep:serde_core"]
 
 [dependencies]
 bytes = { version = "1", optional = true, default-features = false }
-serde = { version = "1", optional = true, default-features = false }
+serde_core = { version = "1.0.221", optional = true, default-features = false }
 malloc_size_of = { version = "0.1.1", optional = true, default-features = false }
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,7 @@ use bytes::{buf::UninitSlice, BufMut};
 #[cfg(feature = "malloc_size_of")]
 use malloc_size_of::{MallocShallowSizeOf, MallocSizeOf, MallocSizeOfOps};
 #[cfg(feature = "serde")]
-use serde::{
+use serde_core::{
     de::{Deserialize, Deserializer, SeqAccess, Visitor},
     ser::{Serialize, SerializeSeq, Serializer},
 };
@@ -2899,7 +2899,7 @@ where
     where
         B: SeqAccess<'de>,
     {
-        use serde::de::Error;
+        use serde_core::de::Error;
         let len = seq.size_hint().unwrap_or(0);
         let mut values = SmallVec::new();
         values.try_reserve(len).map_err(B::Error::custom)?;


### PR DESCRIPTION
[serde_core](https://crates.io/crates/serde_core) has just been released. Crates that don't depend on serde derive macros should use it instead of `serde`, as it speeds up compile times by having the build for the crate itself be independent from `serde-derive` (in case it were to be enabled by some other crate). See the serde_core docs for more info.

On my Ryzen 5 5500U, the clean release build time for just `smallvec` in a project containing `smallvec` with the `serde` feature enabled, and `serde` with the `derive` feature enabled, went from 4.61s to 2.34s.