### PR TITLE
Switch `serde` dependency to `serde_core` for v1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,13 +21,14 @@ may_dangle = []
 drain_filter = []
 drain_keep_rest = ["drain_filter"]
 impl_bincode = ["bincode", "unty"]
+serde = ["serde_core"]
 
 # UNSTABLE FEATURES (requires Rust nightly)
 # Enable to use the #[debugger_visualizer] attribute.
 debugger_visualizer = []
 
 [dependencies]
-serde = { version = "1", optional = true, default-features = false }
+serde_core = { version = "1.0.221", optional = true, default-features = false }
 malloc_size_of = { version = "0.1", optional = true, default-features = false }
 arbitrary = { version = "1", optional = true }
 bincode = { version = "2", optional = true, default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,7 +130,7 @@ use core::slice::{self, SliceIndex};
 use malloc_size_of::{MallocShallowSizeOf, MallocSizeOf, MallocSizeOfOps};
 
 #[cfg(feature = "serde")]
-use serde::{
+use serde_core::{
     de::{Deserialize, Deserializer, SeqAccess, Visitor},
     ser::{Serialize, SerializeSeq, Serializer},
 };
@@ -1962,7 +1962,7 @@ where
     where
         B: SeqAccess<'de>,
     {
-        use serde::de::Error;
+        use serde_core::de::Error;
         let len = seq.size_hint().unwrap_or(0);
         let mut values = SmallVec::new();
         values.try_reserve(len).map_err(B::Error::custom)?;


### PR DESCRIPTION
Backport of #393