### PR TITLE
Exclude development script from Cargo publishing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["small", "vec", "vector", "stack", "no_std"]
 categories = ["data-structures"]
 readme = "README.md"
 documentation = "https://docs.rs/smallvec/"
+include = ["Cargo.toml", "LICENSE-MIT", "LICENSE-APACHE", "README.md", "src/**/*.rs"]
 
 [features]
 std = []


### PR DESCRIPTION
During a dependency review we noticed that the smallvec crate includes a development script. This development script shouldn't be there as they might, at some point become problematic. As of now they prevent any downstream user from enabling the `[bans.build.interpreted]` option of cargo deny.

I opted for using an explicit include list instead of an exclude list to prevent these files from beeing included in the published packages to make sure that everything that's included is an conscious choice.

The same as #397 but for the v2 branch