### PR TITLE
Added SmallVec::push_mut andSmallVec::insert_mut

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1505,24 +1505,33 @@ impl<T, const N: usize> SmallVec<T, N> {
 
     #[inline]
     pub fn insert(&mut self, index: usize, value: T) {
+        _ = self.insert_mut(index, value);
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn insert_mut(&mut self, index: usize, value: T) -> &mut T {
         let len = self.len();
         assert!(
             index <= len,
             "insertion index (is {index}) should be <= len (is {len})"
         );
         self.reserve(1);
-        let ptr = self.as_mut_ptr();
+        let mut ptr = self.as_mut_ptr();
         unsafe {
             // the elements at `index + 1..len + 1` are now initialized
             if index < len {
                 copy(ptr.add(index), ptr.add(index + 1), len - index);
             }
             // the element at `index` is now initialized
-            ptr.add(index).write(value);
+            ptr = ptr.add(index);
+            ptr.write(value);
 
             // SAFETY: all the elements are initialized
             self.set_len(len + 1);
         }
+        let result = unsafe { ptr.as_mut() };
+        unsafe { result.unwrap_unchecked() }
     }
 
     #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1214,13 +1214,15 @@ impl<T, const N: usize> SmallVec<T, N> {
             self.reserve(1);
         }
 
-        // SAFETY: both the input and output are within the allocation
+        // SAFETY: `len < capacity` after the reserve,
+        //         so the offset stays in bounds of the allocation.
         let ptr = unsafe { self.as_mut_ptr().add(len) };
-        // SAFETY: we allocated enough space in case it wasn't enough,
-        //         so the address is valid for writes.
+
+        // SAFETY: the slot at `len` is free and properly aligned for `T`.
         unsafe { ptr.write(value) };
 
-        // unsafe { self.set_len(len + 1) };
+        // SAFETY: all elements in `0..len + 1` are initialized.
+        //unsafe { self.set_len(len + 1) };
         {
             // This block is an exact copy of `self.set_len`.
             // We have to do this so that Miri doesn't report a "Stacked Borrows" rule violation.
@@ -1232,6 +1234,8 @@ impl<T, const N: usize> SmallVec<T, N> {
             self.len = TaggedLen::new(new_len, on_heap);
         }
 
+        // SAFETY: `ptr` is aligned, non-null and points to the element initialized above;
+        //         the borrow is tied to `&mut self`, so it is exclusive.
         unsafe { &mut *ptr }
     }
 
@@ -1497,31 +1501,48 @@ impl<T, const N: usize> SmallVec<T, N> {
 
     #[inline]
     pub fn insert(&mut self, index: usize, value: T) {
+        _ = self.insert_mut(index, value);
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn insert_mut(&mut self, index: usize, value: T) -> &mut T {
         let len = self.len();
         assert!(
             index <= len,
             "insertion index (is {index}) should be <= len (is {len})"
         );
         self.reserve(1);
-        let ptr = self.as_mut_ptr();
-        unsafe {
-            // the elements at `index + 1..len + 1` are now initialized
-            if index < len {
-                copy(ptr.add(index), ptr.add(index + 1), len - index);
-            }
-            // the element at `index` is now initialized
-            ptr.add(index).write(value);
 
-            // SAFETY: all the elements are initialized
-            self.set_len(len + 1);
-        }
-    }
-
-    #[inline]
-    #[must_use]
-    pub fn insert_mut(&mut self, index: usize, value: T) -> &mut T {
-        let () = self.insert(index, value);
+        // SAFETY: `index <= len <= capacity`,
+        //         so the offset stays in bounds of the allocation.
         let ptr = unsafe { self.as_mut_ptr().add(index) };
+
+        if index < len {
+            // SAFETY: `reserve(1)` guarantees capacity for `len + 1` elements,
+            //         so shifting `len - index` elements one slot up stays in bounds.
+            //         Source and destination overlap, hence `copy` instead of `copy_nonoverlapping`.
+            unsafe { copy(ptr, ptr.add(1), len - index) };
+        }
+
+        // SAFETY: the slot at `index` is free and properly aligned for `T`.
+        unsafe { ptr.write(value) };
+
+        // SAFETY: all elements in `0..len + 1` are initialized.
+        //unsafe { self.set_len(len + 1) };
+        {
+            // This block is an exact copy of `self.set_len`.
+            // We have to do this so that Miri doesn't report a "Stacked Borrows" rule violation.
+            // See PR/406
+
+            let new_len = len + 1;
+            debug_assert!(new_len <= self.capacity());
+            let on_heap = self.len.on_heap();
+            self.len = TaggedLen::new(new_len, on_heap);
+        }
+
+        // SAFETY: `ptr` is aligned, non-null and points to the element initialized above;
+        //         the borrow is tied to `&mut self`, so it is exclusive.
         unsafe { &mut *ptr }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -292,7 +292,7 @@ impl<T> Clone for TaggedLen<T> {
     fn clone(&self) -> Self {
         Self(self.0, PhantomData)
     }
-    
+
     #[inline]
     fn clone_from(&mut self, source: &Self) {
         self.0 = source.0;
@@ -1203,24 +1203,35 @@ impl<T, const N: usize> SmallVec<T, N> {
 
     #[inline]
     pub fn push(&mut self, value: T) {
-        let len = self.len();
-        if len == self.capacity() {
-            self.reserve(1);
-        }
-        // SAFETY: both the input and output are within the allocation
-        let ptr = unsafe { self.as_mut_ptr().add(len) };
-        // SAFETY: we allocated enough space in case it wasn't enough, so the address is valid for
-        // writes.
-        unsafe { ptr.write(value) };
-        unsafe { self.set_len(len + 1) };
+        _ = self.push_mut(value);
     }
 
     #[inline]
     #[must_use]
     pub fn push_mut(&mut self, value: T) -> &mut T {
-        let idx = self.len();
-        let () = self.push(value);
-        let ptr = unsafe { self.as_mut_ptr().add(idx) };
+        let len = self.len();
+        if len == self.capacity() {
+            self.reserve(1);
+        }
+
+        // SAFETY: both the input and output are within the allocation
+        let ptr = unsafe { self.as_mut_ptr().add(len) };
+        // SAFETY: we allocated enough space in case it wasn't enough,
+        //         so the address is valid for writes.
+        unsafe { ptr.write(value) };
+
+        // unsafe { self.set_len(len + 1) };
+        {
+            // This block is an exact copy of `self.set_len`.
+            // We have to do this so that Miri doesn't report a "Stacked Borrows" rule violation.
+            // See PR/406
+
+            let new_len = len + 1;
+            debug_assert!(new_len <= self.capacity());
+            let on_heap = self.len.on_heap();
+            self.len = TaggedLen::new(new_len, on_heap);
+        }
+
         unsafe { &mut *ptr }
     }
 
@@ -1829,10 +1840,10 @@ impl<T: Clone, const N: usize> SmallVec<T, N> {
     where
         T: Copy
     {
-        
+
         let len = other.len();
         let src = other.as_ptr();
-        
+
         let l = self.len();
         self.reserve(len);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -493,7 +493,10 @@ impl<T, const N: usize> Drain<'_, T, N> {
         let range_start = vec.len();
         let range_end = self.tail_start;
         let range_slice = unsafe {
-            core::slice::from_raw_parts_mut(vec.as_mut_ptr().add(range_start), range_end - range_start)
+            core::slice::from_raw_parts_mut(
+                vec.as_mut_ptr().add(range_start),
+                range_end - range_start,
+            )
         };
 
         for place in range_slice {
@@ -689,7 +692,11 @@ impl<I: Iterator, const N: usize> Drop for Splice<'_, I, N> {
             }
 
             // Collect any remaining elements.
-            let mut collected = self.replace_with.by_ref().collect::<SmallVec<I::Item, N>>().into_iter();
+            let mut collected = self
+                .replace_with
+                .by_ref()
+                .collect::<SmallVec<I::Item, N>>()
+                .into_iter();
             // Now we have an exact count.
             if collected.len() > 0 {
                 self.drain.move_tail(collected.len());
@@ -725,7 +732,6 @@ unsafe impl<T, const N: usize> Send for IntoIter<T, N> where T: Send {}
 unsafe impl<T, const N: usize> Sync for IntoIter<T, N> where T: Sync {}
 
 impl<T, const N: usize> IntoIter<T, N> {
-
     #[inline]
     const fn as_ptr(&self) -> *const T {
         let on_heap = self.end.on_heap();
@@ -754,10 +760,7 @@ impl<T, const N: usize> IntoIter<T, N> {
         // So the pointer arithmetic is valid, and so is the construction of the slice
         unsafe {
             let ptr = self.as_ptr();
-            core::slice::from_raw_parts(
-                ptr.add(self.begin),
-                self.end.value() - self.begin,
-            )
+            core::slice::from_raw_parts(ptr.add(self.begin), self.end.value() - self.begin)
         }
     }
 
@@ -766,10 +769,7 @@ impl<T, const N: usize> IntoIter<T, N> {
         // SAFETY: see above
         unsafe {
             let ptr = self.as_mut_ptr();
-            core::slice::from_raw_parts_mut(
-                ptr.add(self.begin),
-                self.end.value() - self.begin,
-            )
+            core::slice::from_raw_parts_mut(ptr.add(self.begin), self.end.value() - self.begin)
         }
     }
 }
@@ -842,7 +842,9 @@ impl<T, const N: usize> SmallVec<T, N> {
 
     #[inline]
     pub const fn from_buf<const S: usize>(elements: [T; S]) -> Self {
-        const { assert!(S <= N); }
+        const {
+            assert!(S <= N);
+        }
 
         // Although we create a new buffer, since S and N are known at compile time,
         // even with `-C opt-level=1`, it gets optimized as best as it could be. (Checked with <godbolt.org>)
@@ -1198,7 +1200,10 @@ impl<T, const N: usize> SmallVec<T, N> {
         R: core::ops::RangeBounds<usize>,
         I: IntoIterator<Item = T>,
     {
-        Splice { drain: self.drain(range), replace_with: replace_with.into_iter() }
+        Splice {
+            drain: self.drain(range),
+            replace_with: replace_with.into_iter(),
+        }
     }
 
     #[inline]
@@ -1257,7 +1262,11 @@ impl<T, const N: usize> SmallVec<T, N> {
     #[inline]
     pub fn pop_if(&mut self, predicate: impl FnOnce(&mut T) -> bool) -> Option<T> {
         let last = self.last_mut()?;
-        if predicate(last) { self.pop() } else { None }
+        if predicate(last) {
+            self.pop()
+        } else {
+            None
+        }
     }
 
     #[inline]
@@ -1422,7 +1431,10 @@ impl<T, const N: usize> SmallVec<T, N> {
                     self.set_inline();
                     alloc::alloc::dealloc(
                         ptr.cast().as_ptr(),
-                        Layout::from_size_align_unchecked(capacity * size_of::<T>(), align_of::<T>()),
+                        Layout::from_size_align_unchecked(
+                            capacity * size_of::<T>(),
+                            align_of::<T>(),
+                        ),
                     );
                 }
             } else if target < self.capacity() {
@@ -1453,7 +1465,10 @@ impl<T, const N: usize> SmallVec<T, N> {
     #[inline]
     pub fn swap_remove(&mut self, index: usize) -> T {
         let len = self.len();
-        assert!(index < len, "swap_remove index (is {index}) should be < len (is {len})");
+        assert!(
+            index < len,
+            "swap_remove index (is {index}) should be < len (is {len})"
+        );
         // This can't overflow since `len > index >= 0`
         let new_len = len - 1;
         unsafe {
@@ -1485,7 +1500,10 @@ impl<T, const N: usize> SmallVec<T, N> {
     #[inline]
     pub fn remove(&mut self, index: usize) -> T {
         let len = self.len();
-        assert!(index < len, "removal index (is {index}) should be < len (is {len})");
+        assert!(
+            index < len,
+            "removal index (is {index}) should be < len (is {len})"
+        );
         let new_len = len - 1;
         unsafe {
             // SAFETY: new_len < len
@@ -1726,7 +1744,9 @@ impl<T, const N: usize> SmallVec<T, N> {
 
     pub fn leak<'a>(self) -> &'a mut [T] {
         if !self.spilled() {
-            panic!("SmallVec::leak() called on inline (stack) SmallVec, which cannot be safely leaked");
+            panic!(
+                "SmallVec::leak() called on inline (stack) SmallVec, which cannot be safely leaked"
+            );
         }
         let mut me = ManuallyDrop::new(self);
         unsafe { core::slice::from_raw_parts_mut(me.as_mut_ptr(), me.len()) }
@@ -1859,9 +1879,8 @@ impl<T: Clone, const N: usize> SmallVec<T, N> {
     #[inline]
     pub fn extend_from_slice_copy(&mut self, other: &[T])
     where
-        T: Copy
+        T: Copy,
     {
-
         let len = other.len();
         let src = other.as_ptr();
 
@@ -1880,7 +1899,7 @@ impl<T: Clone, const N: usize> SmallVec<T, N> {
     pub fn extend_from_within_copy<R>(&mut self, src: R)
     where
         R: core::ops::RangeBounds<usize>,
-        T: Copy
+        T: Copy,
     {
         let src = slice_range(src, ..self.len());
         let core::ops::Range { start, end } = src;
@@ -1899,7 +1918,7 @@ impl<T: Clone, const N: usize> SmallVec<T, N> {
 
     pub fn insert_from_slice_copy(&mut self, index: usize, other: &[T])
     where
-        T: Copy
+        T: Copy,
     {
         let l = self.len();
         let len = other.len();
@@ -1923,7 +1942,7 @@ impl<T: Clone, const N: usize> SmallVec<T, N> {
     /// for types with the [`Copy`] trait.
     pub fn from_slice_copy(slice: &[T]) -> Self
     where
-        T: Copy
+        T: Copy,
     {
         let src = slice.as_ptr();
         let len = slice.len();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1203,12 +1203,6 @@ impl<T, const N: usize> SmallVec<T, N> {
 
     #[inline]
     pub fn push(&mut self, value: T) {
-        _ = self.push_mut(value);
-    }
-
-    #[inline]
-    #[must_use]
-    pub fn push_mut(&mut self, value: T) -> &mut T {
         let len = self.len();
         if len == self.capacity() {
             self.reserve(1);
@@ -1218,7 +1212,15 @@ impl<T, const N: usize> SmallVec<T, N> {
         // SAFETY: we allocated enough space in case it wasn't enough, so the address is valid for
         // writes.
         unsafe { ptr.write(value) };
-        unsafe { self.set_len(len + 1) }
+        unsafe { self.set_len(len + 1) };
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn push_mut(&mut self, value: T) -> &mut T {
+        let idx = self.len();
+        let () = self.push(value);
+        let ptr = unsafe { self.as_mut_ptr().add(idx) };
         unsafe { &mut *ptr }
     }
 
@@ -1484,30 +1486,32 @@ impl<T, const N: usize> SmallVec<T, N> {
 
     #[inline]
     pub fn insert(&mut self, index: usize, value: T) {
-        _ = self.insert_mut(index, value);
-    }
-
-    #[inline]
-    #[must_use]
-    pub fn insert_mut(&mut self, index: usize, value: T) -> &mut T {
         let len = self.len();
-        assert!(index <= len, "insertion index (is {index}) should be <= len (is {len})");
+        assert!(
+            index <= len,
+            "insertion index (is {index}) should be <= len (is {len})"
+        );
         self.reserve(1);
-        let mut ptr = self.as_mut_ptr();
+        let ptr = self.as_mut_ptr();
         unsafe {
             // the elements at `index + 1..len + 1` are now initialized
             if index < len {
                 copy(ptr.add(index), ptr.add(index + 1), len - index);
             }
             // the element at `index` is now initialized
-            ptr = ptr.add(index);
-            ptr.write(value);
+            ptr.add(index).write(value);
 
             // SAFETY: all the elements are initialized
             self.set_len(len + 1);
-
-            &mut *ptr
         }
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn insert_mut(&mut self, index: usize, value: T) -> &mut T {
+        let () = self.insert(index, value);
+        let ptr = unsafe { self.as_mut_ptr().add(index) };
+        unsafe { &mut *ptr }
     }
 
     #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1226,8 +1226,7 @@ impl<T, const N: usize> SmallVec<T, N> {
         // SAFETY: the slot at `len` is free and properly aligned for `T`.
         unsafe { ptr.write(value) };
 
-        // SAFETY: all elements in `0..len + 1` are initialized.
-        //unsafe { self.set_len(len + 1) };
+        // LEGAL: all elements in `0..len + 1` are initialized.
         {
             // This block is an exact copy of `self.set_len`.
             // We have to do this so that Miri doesn't report a "Stacked Borrows" rule violation.
@@ -1546,8 +1545,7 @@ impl<T, const N: usize> SmallVec<T, N> {
         // SAFETY: the slot at `index` is free and properly aligned for `T`.
         unsafe { ptr.write(value) };
 
-        // SAFETY: all elements in `0..len + 1` are initialized.
-        //unsafe { self.set_len(len + 1) };
+        // LEGAL: all elements in `0..len + 1` are initialized.
         {
             // This block is an exact copy of `self.set_len`.
             // We have to do this so that Miri doesn't report a "Stacked Borrows" rule violation.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -292,7 +292,7 @@ impl<T> Clone for TaggedLen<T> {
     fn clone(&self) -> Self {
         Self(self.0, PhantomData)
     }
-
+    
     #[inline]
     fn clone_from(&mut self, source: &Self) {
         self.0 = source.0;
@@ -493,10 +493,7 @@ impl<T, const N: usize> Drain<'_, T, N> {
         let range_start = vec.len();
         let range_end = self.tail_start;
         let range_slice = unsafe {
-            core::slice::from_raw_parts_mut(
-                vec.as_mut_ptr().add(range_start),
-                range_end - range_start,
-            )
+            core::slice::from_raw_parts_mut(vec.as_mut_ptr().add(range_start), range_end - range_start)
         };
 
         for place in range_slice {
@@ -692,11 +689,7 @@ impl<I: Iterator, const N: usize> Drop for Splice<'_, I, N> {
             }
 
             // Collect any remaining elements.
-            let mut collected = self
-                .replace_with
-                .by_ref()
-                .collect::<SmallVec<I::Item, N>>()
-                .into_iter();
+            let mut collected = self.replace_with.by_ref().collect::<SmallVec<I::Item, N>>().into_iter();
             // Now we have an exact count.
             if collected.len() > 0 {
                 self.drain.move_tail(collected.len());
@@ -732,6 +725,7 @@ unsafe impl<T, const N: usize> Send for IntoIter<T, N> where T: Send {}
 unsafe impl<T, const N: usize> Sync for IntoIter<T, N> where T: Sync {}
 
 impl<T, const N: usize> IntoIter<T, N> {
+
     #[inline]
     const fn as_ptr(&self) -> *const T {
         let on_heap = self.end.on_heap();
@@ -760,7 +754,10 @@ impl<T, const N: usize> IntoIter<T, N> {
         // So the pointer arithmetic is valid, and so is the construction of the slice
         unsafe {
             let ptr = self.as_ptr();
-            core::slice::from_raw_parts(ptr.add(self.begin), self.end.value() - self.begin)
+            core::slice::from_raw_parts(
+                ptr.add(self.begin),
+                self.end.value() - self.begin,
+            )
         }
     }
 
@@ -769,7 +766,10 @@ impl<T, const N: usize> IntoIter<T, N> {
         // SAFETY: see above
         unsafe {
             let ptr = self.as_mut_ptr();
-            core::slice::from_raw_parts_mut(ptr.add(self.begin), self.end.value() - self.begin)
+            core::slice::from_raw_parts_mut(
+                ptr.add(self.begin),
+                self.end.value() - self.begin,
+            )
         }
     }
 }
@@ -842,9 +842,7 @@ impl<T, const N: usize> SmallVec<T, N> {
 
     #[inline]
     pub const fn from_buf<const S: usize>(elements: [T; S]) -> Self {
-        const {
-            assert!(S <= N);
-        }
+        const { assert!(S <= N); }
 
         // Although we create a new buffer, since S and N are known at compile time,
         // even with `-C opt-level=1`, it gets optimized as best as it could be. (Checked with <godbolt.org>)
@@ -1200,10 +1198,7 @@ impl<T, const N: usize> SmallVec<T, N> {
         R: core::ops::RangeBounds<usize>,
         I: IntoIterator<Item = T>,
     {
-        Splice {
-            drain: self.drain(range),
-            replace_with: replace_with.into_iter(),
-        }
+        Splice { drain: self.drain(range), replace_with: replace_with.into_iter() }
     }
 
     #[inline]
@@ -1218,16 +1213,13 @@ impl<T, const N: usize> SmallVec<T, N> {
         if len == self.capacity() {
             self.reserve(1);
         }
-
         // SAFETY: both the input and output are within the allocation
         let ptr = unsafe { self.as_mut_ptr().add(len) };
         // SAFETY: we allocated enough space in case it wasn't enough, so the address is valid for
         // writes.
         unsafe { ptr.write(value) };
         unsafe { self.set_len(len + 1) }
-
-        let result = unsafe { ptr.as_mut() };
-        unsafe { result.unwrap_unchecked() }
+        unsafe { &mut *ptr }
     }
 
     #[inline]
@@ -1248,11 +1240,7 @@ impl<T, const N: usize> SmallVec<T, N> {
     #[inline]
     pub fn pop_if(&mut self, predicate: impl FnOnce(&mut T) -> bool) -> Option<T> {
         let last = self.last_mut()?;
-        if predicate(last) {
-            self.pop()
-        } else {
-            None
-        }
+        if predicate(last) { self.pop() } else { None }
     }
 
     #[inline]
@@ -1417,10 +1405,7 @@ impl<T, const N: usize> SmallVec<T, N> {
                     self.set_inline();
                     alloc::alloc::dealloc(
                         ptr.cast().as_ptr(),
-                        Layout::from_size_align_unchecked(
-                            capacity * size_of::<T>(),
-                            align_of::<T>(),
-                        ),
+                        Layout::from_size_align_unchecked(capacity * size_of::<T>(), align_of::<T>()),
                     );
                 }
             } else if target < self.capacity() {
@@ -1451,10 +1436,7 @@ impl<T, const N: usize> SmallVec<T, N> {
     #[inline]
     pub fn swap_remove(&mut self, index: usize) -> T {
         let len = self.len();
-        assert!(
-            index < len,
-            "swap_remove index (is {index}) should be < len (is {len})"
-        );
+        assert!(index < len, "swap_remove index (is {index}) should be < len (is {len})");
         // This can't overflow since `len > index >= 0`
         let new_len = len - 1;
         unsafe {
@@ -1486,10 +1468,7 @@ impl<T, const N: usize> SmallVec<T, N> {
     #[inline]
     pub fn remove(&mut self, index: usize) -> T {
         let len = self.len();
-        assert!(
-            index < len,
-            "removal index (is {index}) should be < len (is {len})"
-        );
+        assert!(index < len, "removal index (is {index}) should be < len (is {len})");
         let new_len = len - 1;
         unsafe {
             // SAFETY: new_len < len
@@ -1512,10 +1491,7 @@ impl<T, const N: usize> SmallVec<T, N> {
     #[must_use]
     pub fn insert_mut(&mut self, index: usize, value: T) -> &mut T {
         let len = self.len();
-        assert!(
-            index <= len,
-            "insertion index (is {index}) should be <= len (is {len})"
-        );
+        assert!(index <= len, "insertion index (is {index}) should be <= len (is {len})");
         self.reserve(1);
         let mut ptr = self.as_mut_ptr();
         unsafe {
@@ -1529,9 +1505,9 @@ impl<T, const N: usize> SmallVec<T, N> {
 
             // SAFETY: all the elements are initialized
             self.set_len(len + 1);
+
+            &mut *ptr
         }
-        let result = unsafe { ptr.as_mut() };
-        unsafe { result.unwrap_unchecked() }
     }
 
     #[inline]
@@ -1714,9 +1690,7 @@ impl<T, const N: usize> SmallVec<T, N> {
 
     pub fn leak<'a>(self) -> &'a mut [T] {
         if !self.spilled() {
-            panic!(
-                "SmallVec::leak() called on inline (stack) SmallVec, which cannot be safely leaked"
-            );
+            panic!("SmallVec::leak() called on inline (stack) SmallVec, which cannot be safely leaked");
         }
         let mut me = ManuallyDrop::new(self);
         unsafe { core::slice::from_raw_parts_mut(me.as_mut_ptr(), me.len()) }
@@ -1849,11 +1823,12 @@ impl<T: Clone, const N: usize> SmallVec<T, N> {
     #[inline]
     pub fn extend_from_slice_copy(&mut self, other: &[T])
     where
-        T: Copy,
+        T: Copy
     {
+        
         let len = other.len();
         let src = other.as_ptr();
-
+        
         let l = self.len();
         self.reserve(len);
 
@@ -1869,7 +1844,7 @@ impl<T: Clone, const N: usize> SmallVec<T, N> {
     pub fn extend_from_within_copy<R>(&mut self, src: R)
     where
         R: core::ops::RangeBounds<usize>,
-        T: Copy,
+        T: Copy
     {
         let src = slice_range(src, ..self.len());
         let core::ops::Range { start, end } = src;
@@ -1888,7 +1863,7 @@ impl<T: Clone, const N: usize> SmallVec<T, N> {
 
     pub fn insert_from_slice_copy(&mut self, index: usize, other: &[T])
     where
-        T: Copy,
+        T: Copy
     {
         let l = self.len();
         let len = other.len();
@@ -1912,7 +1887,7 @@ impl<T: Clone, const N: usize> SmallVec<T, N> {
     /// for types with the [`Copy`] trait.
     pub fn from_slice_copy(slice: &[T]) -> Self
     where
-        T: Copy,
+        T: Copy
     {
         let src = slice.as_ptr();
         let len = slice.len();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1208,16 +1208,26 @@ impl<T, const N: usize> SmallVec<T, N> {
 
     #[inline]
     pub fn push(&mut self, value: T) {
+        _ = self.push_mut(value);
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn push_mut(&mut self, value: T) -> &mut T {
         let len = self.len();
         if len == self.capacity() {
             self.reserve(1);
         }
+
         // SAFETY: both the input and output are within the allocation
         let ptr = unsafe { self.as_mut_ptr().add(len) };
         // SAFETY: we allocated enough space in case it wasn't enough, so the address is valid for
         // writes.
         unsafe { ptr.write(value) };
         unsafe { self.set_len(len + 1) }
+
+        let result = unsafe { ptr.as_mut() };
+        unsafe { result.unwrap_unchecked() }
     }
 
     #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1261,8 +1261,8 @@ impl<T, const N: usize> SmallVec<T, N> {
         // LEGAL: all elements in `0..len + 1` are initialized.
         {
             // This block is an exact copy of `self.set_len`.
-            // We have to do this so that Miri doesn't report a "Stacked Borrows" rule violation.
-            // See PR/406
+            // We have to do this so that Miri doesn't report a "Stacked Borrows"
+            // rule violation. See PR/406
 
             let new_len = len + 1;
             debug_assert!(new_len <= self.capacity());
@@ -1270,8 +1270,8 @@ impl<T, const N: usize> SmallVec<T, N> {
             self.len = TaggedLen::new(new_len, on_heap);
         }
 
-        // SAFETY: `ptr` is aligned, non-null and points to the element initialized above;
-        //         the borrow is tied to `&mut self`, so it is exclusive.
+        // SAFETY: `ptr` is aligned, non-null and points to the element initialized
+        //         above; the borrow is tied to `&mut self`, so it is exclusive.
         unsafe { &mut *ptr }
     }
 
@@ -1572,7 +1572,8 @@ impl<T, const N: usize> SmallVec<T, N> {
         if index < len {
             // SAFETY: `reserve(1)` guarantees capacity for `len + 1` elements,
             //         so shifting `len - index` elements one slot up stays in bounds.
-            //         Source and destination overlap, hence `copy` instead of `copy_nonoverlapping`.
+            //         Source and destination overlap, hence `copy` instead of
+            //         `copy_nonoverlapping`.
             unsafe { copy(ptr, ptr.add(1), len - index) };
         }
 
@@ -1582,8 +1583,8 @@ impl<T, const N: usize> SmallVec<T, N> {
         // LEGAL: all elements in `0..len + 1` are initialized.
         {
             // This block is an exact copy of `self.set_len`.
-            // We have to do this so that Miri doesn't report a "Stacked Borrows" rule violation.
-            // See PR/406
+            // We have to do this so that Miri doesn't report a "Stacked Borrows"
+            // rule violation. See PR/406
 
             let new_len = len + 1;
             debug_assert!(new_len <= self.capacity());
@@ -1591,8 +1592,8 @@ impl<T, const N: usize> SmallVec<T, N> {
             self.len = TaggedLen::new(new_len, on_heap);
         }
 
-        // SAFETY: `ptr` is aligned, non-null and points to the element initialized above;
-        //         the borrow is tied to `&mut self`, so it is exclusive.
+        // SAFETY: `ptr` is aligned, non-null and points to the element initialized
+        //         above; the borrow is tied to `&mut self`, so it is exclusive.
         unsafe { &mut *ptr }
     }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -20,6 +20,20 @@ pub fn test_zero() {
 // We heap allocate all these strings so that double frees will show up under valgrind.
 
 #[test]
+pub fn test_push_mut() {
+    let mut v = SmallVec::<_, 16>::new();
+
+    let first_elem = v.push_mut("hello".to_owned());
+    assert_eq!(&*first_elem, &"hello".to_owned());
+
+    *first_elem = "hi".to_owned();
+    assert_eq!(&*first_elem, &"hi".to_owned());
+
+    v.push("there".to_owned());
+    assert_eq!(&*v, &["hi".to_owned(), "there".to_owned(),][..]);
+}
+
+#[test]
 pub fn test_inline() {
     let mut v = SmallVec::<_, 16>::new();
     v.push("hello".to_owned());

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -34,6 +34,24 @@ pub fn test_push_mut() {
 }
 
 #[test]
+pub fn test_insert_mut() {
+    let mut v = SmallVec::<_, 16>::new();
+    v.push("hello".to_owned());
+    v.push("there".to_owned());
+
+    let second_elem = v.insert_mut(1, ",".to_owned());
+    assert_eq!(&*second_elem, &",".to_owned());
+
+    *second_elem = ";".to_owned();
+    assert_eq!(&*second_elem, &";".to_owned());
+
+    assert_eq!(
+        &*v,
+        &["hello".to_owned(), ";".to_owned(), "there".to_owned(),][..]
+    );
+}
+
+#[test]
 pub fn test_inline() {
     let mut v = SmallVec::<_, 16>::new();
     v.push("hello".to_owned());


### PR DESCRIPTION
The `push_mut` feature (https://github.com/rust-lang/rust/issues/135974) has already been merged and is expected to be included in the Rust 1.95 stable release. For this reason, we should also add `push_mut` and `insert_mut` here.