### PR TITLE
Fix use-after-free in DrainFilter::keep_rest for SmallVec with capacity 0

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -602,7 +602,7 @@ where
 
         unsafe {
             // ZSTs have no identity, so we don't need to move them around.
-            let needs_move = mem::size_of::<T>() != 0;
+            let needs_move = mem::size_of::<T::Item>() != 0;
 
             if needs_move && this.idx < this.old_len && this.del > 0 {
                 let ptr = this.vec.as_mut_ptr();

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1040,6 +1040,29 @@ fn drain_keep_rest() {
     assert_eq!(a, SmallVec::<[i32; 3]>::from_slice(&[1i32, 3, 5, 6, 7, 8]));
 }
 
+// Regression test: keep_rest on a SmallVec with zero inline capacity must
+// still move tail elements to fill the gap left by drained items.
+// Using Box<u8> so that Miri detects the use-after-move / double-drop
+// caused by the missing backshift.
+#[cfg(feature = "drain_keep_rest")]
+#[test]
+fn drain_keep_rest_zero_inline_capacity() {
+    let mut a: SmallVec<[Box<u8>; 0]> = SmallVec::new();
+    for i in 1u8..=8 {
+        a.push(Box::new(i));
+    }
+
+    let mut df = a.drain_filter(|x| **x % 2 == 0);
+
+    assert_eq!(*df.next().unwrap(), 2);
+    assert_eq!(*df.next().unwrap(), 4);
+
+    df.keep_rest();
+
+    let values: Vec<u8> = a.iter().map(|b| **b).collect();
+    assert_eq!(values, vec![1, 3, 5, 6, 7, 8]);
+}
+
 /// This assortment of tests, in combination with miri, verifies we handle UB on fishy arguments
 /// given to SmallVec. Draining and extending the allocation are fairly well-tested earlier, but
 /// `smallvec.insert(usize::MAX, val)` once slipped by!


### PR DESCRIPTION
In current v1, `keep_rest()` checks `mem::size_of::<T>()` (the Array type) instead of `mem::size_of::<T::Item>()` (the element type) to decide whether to backshift tail elements. For `SmallVec<[T; 0]>`, the array size is always 0, so the backshift is skipped and subsequent accesses read freed memory.

This PR adds a test that triggers the issue under miri, reproducible by `cargo +nightly miri test`, and then applies the one-line fix in a subsequent commit.

This does **not** appear to be exploitable in practice since it requires activating a non-default Cargo feature combined with SmallVec with inline capacity 0. Using capacity 0 is rather silly - you should just use `std::Vec` at that point - so I don't expect this configuration to be common in the wild.

The issue was autonomously discovered by Claude Opus 4.6, but I have manually verified the PoC and the fix.