### PR TITLE
Bump version.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 edition = "2018"
 authors = ["The Servo Project Developers"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
 * #397 - Exclude development script.
 * #407 - Fix use-after-free in DrainFilter::keep_rest for SmallVec with capacity 0.
 * #410 - Work around rustc performance regression.