### PR TITLE
Include debug_metadata/*.natvis in the published crate to fix debugger_visualizer/docs.rs build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["small", "vec", "vector", "stack", "no_std"]
 categories = ["data-structures"]
 readme = "README.md"
 documentation = "https://docs.rs/smallvec/"
-include = ["Cargo.toml", "LICENSE-MIT", "LICENSE-APACHE", "README.md", "src/**/*.rs"]
+include = ["Cargo.toml", "LICENSE-MIT", "LICENSE-APACHE", "README.md", "src/**/*.rs", "debug_metadata/*.natvis"]
 
 [features]
 const_generics = []


### PR DESCRIPTION
## What

Add `debug_metadata/*.natvis` to the `include` allow-list in `Cargo.toml` so the natvis debugger-visualizer file is shipped in the published crate.

```diff
-include = ["Cargo.toml", "LICENSE-MIT", "LICENSE-APACHE", "README.md", "src/**/*.rs"]
+include = ["Cargo.toml", "LICENSE-MIT", "LICENSE-APACHE", "README.md", "src/**/*.rs", "debug_metadata/*.natvis"]
```

## Why

Fixes #415.

The `include` allow-list added in #397 (to keep dev scripts out of the package) omitted `debug_metadata/smallvec.natvis`. But `src/lib.rs` references that file:

```rust
#![cfg_attr(
    feature = "debugger_visualizer",
    feature(debugger_visualizer),
    debugger_visualizer(natvis_file = "../debug_metadata/smallvec.natvis")
)]
```

Because the file is no longer packaged, the published 1.15.2 crate fails to compile whenever the `debugger_visualizer` feature is enabled:

```
error: couldn't read src/../debug_metadata/smallvec.natvis: No such file or directory (os error 2)
```

This is why the docs.rs build for 1.15.2 is red (docs.rs builds with `--all-features` on nightly), and it also breaks any downstream crate that enables the feature. Shipping the file fixes both, rather than just dropping the feature from docs.rs metadata. The tight `debug_metadata/*.natvis` glob keeps unrelated dev files out, consistent with #397's intent.

## Testing

Metadata/packaging fix, so verified via `cargo package`:

- `cargo package --list` now lists `debug_metadata/smallvec.natvis` (previously absent).
- Building the *packaged* crate reproduces the bug before and confirms the fix after:
  - Before: `cd target/package/smallvec-1.15.2 && cargo +nightly build --features debugger_visualizer` fails with the `couldn't read ...smallvec.natvis` error above.
  - After: the same build succeeds.
- Existing suite unaffected: `cargo test` passes (no source change); `cargo +nightly test --test debugger_visualizer --features debugger_visualizer` compiles against the natvis file and passes.
