### PR TITLE
Reduce bloat from `smallvec!` in the inline case

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2672,14 +2672,7 @@ macro_rules! smallvec {
         $crate::from_elem($elem, $n)
     });
     ($($x:expr),+$(,)?) => ({
-        const COUNT: usize = 0usize $(+ $crate::smallvec!(@one $x))+;
-        let mut vec = $crate::SmallVec::new();
-        if COUNT <= vec.capacity() {
-            $(vec.push($x);)*
-            vec
-        } else {
-            $crate::SmallVec::from_vec($crate::alloc::vec![$($x,)+])
-        }
+        $crate::SmallVec::from([$($x,)+])
     });
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2667,7 +2667,7 @@ macro_rules! smallvec {
         $crate::from_elem($elem, $n)
     });
     ($($($x:expr),+$(,)?)?) => ({
-        $crate::SmallVec::from([$($($x,)+)?])
+        $crate::SmallVec::from([$($($x),+)?])
     });
 }
 
@@ -2680,7 +2680,7 @@ macro_rules! smallvec_inline {
     });
     ($($x:expr),+ $(,)?) => ({
         const N: usize = 0usize $(+ $crate::smallvec_inline!(@one $x))*;
-        $crate::SmallVec::<_, N>::from_buf([$($x,)*])
+        $crate::SmallVec::<_, N>::from_buf([$($x),*])
     });
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2663,16 +2663,11 @@ impl<T, const N: usize> core::iter::FromIterator<T> for SmallVec<T, N> {
 
 #[macro_export]
 macro_rules! smallvec {
-    // count helper: transform any expression into 1
-    (@one $x:expr) => (1usize);
-    () => (
-        $crate::SmallVec::new()
-    );
     ($elem:expr; $n:expr) => ({
         $crate::from_elem($elem, $n)
     });
-    ($($x:expr),+$(,)?) => ({
-        $crate::SmallVec::from([$($x,)+])
+    ($($($x:expr),+$(,)?)?) => ({
+        $crate::SmallVec::from([$($($x,)+)?])
     });
 }
 


### PR DESCRIPTION
See #418 for details.