### PR TITLE
Fix retain_mut panic and drop behavior

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1610,21 +1610,7 @@ impl<T, const N: usize> SmallVec<T, N> {
 
     #[inline]
     pub fn retain_mut<F: FnMut(&mut T) -> bool>(&mut self, mut f: F) {
-        let mut del = 0;
-        let len = self.len();
-        let ptr = self.as_mut_ptr();
-        for i in 0..len {
-            // SAFETY: all the pointers are in bounds
-            // `i - del` never overflows since `del <= i` is a maintained invariant
-            unsafe {
-                if !f(&mut *ptr.add(i)) {
-                    del += 1;
-                } else if del > 0 {
-                    core::ptr::swap(ptr.add(i), ptr.add(i - del));
-                }
-            }
-        }
-        self.truncate(len - del);
+        self.extract_if(.., |element| !f(element)).for_each(drop);
     }
 
     #[inline]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,5 +1,6 @@
 use crate::{smallvec, SmallVec};
 
+use core::cell::{Cell, RefCell};
 use core::hash::Hasher;
 use core::iter::FromIterator;
 
@@ -746,6 +747,111 @@ fn test_retain() {
     assert_eq!(Rc::strong_count(&one), 2);
     sv.retain(|_| false);
     assert_eq!(Rc::strong_count(&one), 1);
+}
+
+fn check_retain_mut_predicate_panic_matches_vec<const N: usize>() {
+    struct Counted {
+        value: i32,
+        drops: Rc<Cell<usize>>,
+    }
+
+    impl Drop for Counted {
+        fn drop(&mut self) {
+            self.drops.set(self.drops.get() + 1);
+        }
+    }
+
+    let drops = Rc::new(Cell::new(0));
+    let mut values = SmallVec::<Counted, N>::new();
+    values.extend((1..=4).map(|value| Counted {
+        value,
+        drops: Rc::clone(&drops),
+    }));
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        values.retain_mut(|item| match item.value {
+            1 => false,
+            3 => panic!("predicate panic"),
+            _ => true,
+        });
+    }));
+
+    assert!(result.is_err());
+    assert_eq!(drops.get(), 1);
+    assert_eq!(
+        values.iter().map(|item| item.value).collect::<Vec<_>>(),
+        vec![2, 3, 4]
+    );
+
+    drop(values);
+    assert_eq!(drops.get(), 4);
+}
+
+#[test]
+fn test_retain_mut_predicate_panic_inline() {
+    check_retain_mut_predicate_panic_matches_vec::<4>();
+}
+
+#[test]
+fn test_retain_mut_predicate_panic_spilled() {
+    check_retain_mut_predicate_panic_matches_vec::<2>();
+}
+
+fn check_retain_mut_drop_panic_stops_visiting<const N: usize>() {
+    struct PanicOnDrop {
+        value: i32,
+        drops: Rc<RefCell<Vec<i32>>>,
+        panic_once: Rc<Cell<bool>>,
+    }
+
+    impl Drop for PanicOnDrop {
+        fn drop(&mut self) {
+            self.drops.borrow_mut().push(self.value);
+            if self.value == 1 && !self.panic_once.replace(true) {
+                panic!("drop panic");
+            }
+        }
+    }
+
+    let drops = Rc::new(RefCell::new(Vec::new()));
+    let visited = Rc::new(RefCell::new(Vec::new()));
+    let panic_once = Rc::new(Cell::new(false));
+    let mut values = SmallVec::<PanicOnDrop, N>::new();
+    values.extend((1..=4).map(|value| PanicOnDrop {
+        value,
+        drops: Rc::clone(&drops),
+        panic_once: Rc::clone(&panic_once),
+    }));
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        values.retain_mut(|item| {
+            visited.borrow_mut().push(item.value);
+            item.value != 1
+        });
+    }));
+
+    assert!(result.is_err());
+    assert_eq!(&*visited.borrow(), &[1]);
+    assert_eq!(&*drops.borrow(), &[1]);
+    assert_eq!(
+        values.iter().map(|item| item.value).collect::<Vec<_>>(),
+        vec![2, 3, 4]
+    );
+
+    drop(values);
+    let mut dropped = drops.borrow().clone();
+    dropped.sort_unstable();
+    assert_eq!(dropped, [1, 2, 3, 4]);
+}
+
+#[test]
+fn test_retain_mut_drop_panic_inline() {
+    check_retain_mut_drop_panic_stops_visiting::<4>();
+}
+
+#[test]
+fn test_retain_mut_drop_panic_spilled() {
+    check_retain_mut_drop_panic_stops_visiting::<2>();
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- make `SmallVec::retain_mut` reuse `ExtractIf`'s existing panic backshift guard
- preserve unprocessed elements when the predicate panics
- stop visiting later elements and repair the vector when dropping a rejected element panics
- cover both inline and spilled storage for predicate and destructor panics

The issue claim mentioned a direct port of `Vec::retain_mut`'s guard. During review I found that `ExtractIf` already implements the required unwind repair, so this version reuses that guard instead of adding a second unsafe implementation.

## Reproduction and validation

All four new tests fail independently on pinned base `b675995e70144f03fd5c5e0ce56d3f98115d0950` and pass with this change.

- `cargo build --verbose`
- `cargo test --verbose` — 68 unit + 1 integration + 6 doctests passed
- `cargo test --verbose --features serde` — 69 unit + 1 integration + 6 doctests passed
- `cargo test --verbose --features malloc_size_of` — 68 unit + 1 integration + 6 doctests passed
- `cargo check --verbose --no-default-features`
- `cargo fmt --all -- --check`
- `git diff HEAD^ --check`

A strict all-target Clippy run is blocked by warnings/lints also reproduced on the pinned base; a library Clippy run passes when allowing those exact baseline lints. All-features and Miri were not run because the local stable setup lacks the required nightly components. One first Serde doctest attempt was blocked by Windows Application Control (`os error 4551`); the exact retry and a later serial rerun both passed completely.

Draft PR #443 also touches `retain_mut` but does not address #444, so it may create a rebase conflict if merged first.

Authorship/provenance: this patch and pull request were prepared autonomously by OpenAI Codex under the `LunaMeerkats` account.

Fixes #444