### PR TITLE
Fix try_grow_raw lead memory leak

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -248,7 +248,7 @@ impl<T, const N: usize> RawSmallVec<T, N> {
             return Err(CollectionAllocErr::CapacityOverflow);
         }
 
-        let new_ptr = if len == 0 || !was_on_heap {
+        let new_ptr = if !was_on_heap {
             // get a fresh allocation
             let new_ptr = alloc(new_layout) as *mut T; // `new_layout` has nonzero size.
             let new_ptr =


### PR DESCRIPTION
There is an issue in the current logic where memory is not correctly released before dropping the last reference. In try_grow_raw, new_ptr decides between reallocating (in-place growth) and allocating fresh memory based on the condition len == 0 || !was_on_heap. However, len == 0 is not equivalent to an empty heap, so the pointer of the abandoned memory block gets overwritten by the newly allocated memory before it is freed — leading to a memory leak.

Sample:

```
use std::alloc::{GlobalAlloc, Layout, System};
use std::sync::atomic::{AtomicUsize, Ordering};
use smallvec::SmallVec;

struct CountingAllocator;
static ALLOCS: AtomicUsize = AtomicUsize::new(0);
static DEALLOCS: AtomicUsize = AtomicUsize::new(0);

unsafe impl GlobalAlloc for CountingAllocator {
    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
        ALLOCS.fetch_add(1, Ordering::SeqCst);
        unsafe { System.alloc(layout) }
    }
    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
        DEALLOCS.fetch_add(1, Ordering::SeqCst);
        unsafe { System.dealloc(ptr, layout) }
    }
    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
        unsafe { System.realloc(ptr, layout, new_size) }
    }
}

#[global_allocator]
static GLOBAL: CountingAllocator = CountingAllocator;

fn outstanding() -> isize {
    ALLOCS.load(Ordering::SeqCst) as isize - DEALLOCS.load(Ordering::SeqCst) as isize
}

fn main() {
    let before = outstanding();
    {
        let mut v: SmallVec<u8, 4> = SmallVec::with_capacity(16); // 堆上，len == 0
        v.grow(32);
        drop(v);  
    }
    println!(
        "unfree {:>2}",
        outstanding() - before
    );

    let before = outstanding();
    {
        let mut v: SmallVec<u8, 4> = SmallVec::new();
        for i in 0..8 {
            v.grow(8 << i); 
            v.clear();
        }
        drop(v);
    }
    println!(
        "unfree = {:>2} ",
        outstanding() - before
    );
}

```
output 
```
   Compiling smallvec v2.0.0-alpha.12 (D:\GitHubPull\rust-smallvec)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.48s
     Running `target\debug\examples\leak_demo.exe`
unfree  1
unfree =  7
```
