### PR TITLE
docs: update v2 status links

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ rust-smallvec
 > change between versions.
 >
 > The status of v2 can be tracked in:
-> - [its tracking issue](https://github.com/servo/rust-smallvec/issues/425)
+> - [the milestones](https://github.com/servo/rust-smallvec/milestones)
 > - [the wiki spec](https://github.com/servo/rust-smallvec/wiki)
 >
 > The source code for the latest smallvec 1.x.y release can be found on the


### PR DESCRIPTION
## Summary

Updates the v2 status section in `README.md` to link to the milestones page instead of the old tracking issue, while keeping the wiki link.

Closes #452

## Testing

- `git diff --check`
- Documentation-only change