### PR TITLE
docs: add contribution guide and code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,14 @@
+# Code of Conduct
+
+The smallvec project follows the [Rust Code of Conduct](https://www.rust-lang.org/policies/code-of-conduct).
+It applies to this repository, its issue tracker, pull requests, and other
+official project spaces.
+
+If you experience or witness unacceptable behavior, report it privately to the
+Servo project maintainers through the contact method described in the
+[Servo contribution guide](https://book.servo.org/contributing/getting-started).
+
+Project participants are expected to be respectful, assume good faith, and
+focus feedback on the work rather than on the person. Maintainers may remove
+comments or contributions that violate this code and may take any other action
+necessary to keep project spaces welcoming and productive.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# Contributing to smallvec
+
+Thank you for helping improve `smallvec`! Before opening a pull request,
+please review the [Servo contribution guide](https://book.servo.org/contributing/getting-started).
+
+## Pull requests
+
+- Keep changes focused and explain the motivation in the pull request.
+- Add or update tests for behavior changes.
+- Run the relevant Rust formatting, test, and lint checks locally.
+- Do not include generated files, credentials, or unrelated formatting changes.
+
+Please be patient during review. Maintainers may ask for revisions so that a
+change remains compatible with the supported Rust versions and the crate's
+API guarantees.


### PR DESCRIPTION
## Summary
- add contributor guidance linked to the Servo book
- document the Rust Code of Conduct for this repository
- include focused PR, testing, and security-boundary expectations

Closes #453
