### PR TITLE
#396 recovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,16 +3,358 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
 name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "3.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
+dependencies = [
+ "bitflags",
+ "clap_lex",
+ "indexmap",
+ "textwrap",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
+name = "criterion"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c76e09c1aae2bc52b3d2f29e13c6572553b30c4aa1b8a49fd70de6412654cb"
+dependencies = [
+ "anes",
+ "atty",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools",
+ "lazy_static",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "either"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
+
+[[package]]
+name = "futures-core"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
+
+[[package]]
+name = "futures-task"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
+
+[[package]]
+name = "futures-util"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "libc"
+version = "0.2.189"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
 name = "malloc_size_of"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5d719de8b8f230028cf8192ae4c1b25267cd6b8a99d2747d345a70b8c81aa13"
+
+[[package]]
+name = "memchr"
+version = "2.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "os_str_bytes"
+version = "6.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -33,12 +375,77 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "regex"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "rustversion"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -58,7 +465,20 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.151"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -71,13 +491,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "smallvec"
 version = "2.0.0-alpha.12"
 dependencies = [
  "bytes",
+ "criterion",
  "malloc_size_of",
  "serde_core",
  "serde_test",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.119"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -92,7 +530,160 @@ dependencies = [
 ]
 
 [[package]]
+name = "textwrap"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,12 @@ malloc_size_of = { version = "0.1.1", optional = true, default-features = false 
 
 [dev-dependencies]
 serde_test = "1.0"
+criterion = "0.4.0"
+
+[[bench]]
+name = "bench"
+path = "benches/bench.rs"
+harness = false
 
 [package.metadata.docs.rs]
 all-features = true

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,10 +1,9 @@
-#![feature(test)]
 #![allow(deprecated)]
 
-extern crate test;
-
+use criterion::{criterion_group, criterion_main, Bencher, Criterion};
 use smallvec::{smallvec, SmallVec};
-use test::Bencher;
+use std::hint::black_box;
+use std::time::Duration;
 
 const VEC_SIZE: usize = 16;
 const SPILLED_SIZE: usize = 100;
@@ -18,39 +17,41 @@ trait Vector<T>: for<'a> From<&'a [T]> + Extend<T> {
     fn from_elem(val: T, n: usize) -> Self;
     fn from_elems(val: &[T]) -> Self;
     fn extend_from_slice(&mut self, other: &[T]);
+    fn retain_mut<F>(&mut self, f: F)
+    where
+        F: FnMut(&mut T) -> bool;
 }
 
 impl<T: Copy> Vector<T> for Vec<T> {
     fn new() -> Self {
         Self::with_capacity(VEC_SIZE)
     }
-
     fn push(&mut self, val: T) {
         self.push(val)
     }
-
     fn pop(&mut self) -> Option<T> {
         self.pop()
     }
-
     fn remove(&mut self, p: usize) -> T {
         self.remove(p)
     }
-
     fn insert(&mut self, n: usize, val: T) {
         self.insert(n, val)
     }
-
     fn from_elem(val: T, n: usize) -> Self {
         vec![val; n]
     }
-
     fn from_elems(val: &[T]) -> Self {
         val.to_owned()
     }
-
     fn extend_from_slice(&mut self, other: &[T]) {
         Vec::extend_from_slice(self, other)
+    }
+    fn retain_mut<F>(&mut self, f: F)
+    where
+        F: FnMut(&mut T) -> bool,
+    {
+        self.retain_mut(f)
     }
 }
 
@@ -58,47 +59,49 @@ impl<T: Copy> Vector<T> for SmallVec<T, VEC_SIZE> {
     fn new() -> Self {
         Self::new()
     }
-
     fn push(&mut self, val: T) {
         self.push(val)
     }
-
     fn pop(&mut self) -> Option<T> {
         self.pop()
     }
-
     fn remove(&mut self, p: usize) -> T {
         self.remove(p)
     }
-
     fn insert(&mut self, n: usize, val: T) {
         self.insert(n, val)
     }
-
     fn from_elem(val: T, n: usize) -> Self {
         smallvec![val; n]
     }
-
     fn from_elems(val: &[T]) -> Self {
         SmallVec::from(val)
     }
-
     fn extend_from_slice(&mut self, other: &[T]) {
         SmallVec::extend_from_slice(self, other)
+    }
+    fn retain_mut<F>(&mut self, f: F)
+    where
+        F: FnMut(&mut T) -> bool,
+    {
+        self.retain_mut(f)
     }
 }
 
 macro_rules! make_benches {
     ($typ:ty { $($b_name:ident => $g_name:ident($($args:expr),*),)* }) => {
         $(
-            #[bench]
-            fn $b_name(b: &mut Bencher) {
-                $g_name::<$typ>($($args,)* b)
+            fn $b_name(c: &mut Criterion) {
+                c.bench_function(stringify!($b_name), |b: &mut Bencher| {
+                    $g_name::<$typ>($($args,)* b)
+                });
             }
         )*
     }
 }
 
+/* ----------  Bench generation (same list, just using the new macro)
+ * ---------- */
 make_benches! {
     SmallVec<u64, VEC_SIZE> {
         bench_push => gen_push(SPILLED_SIZE as _),
@@ -122,6 +125,12 @@ make_benches! {
         bench_macro_from_elem => gen_from_elem(SPILLED_SIZE as _),
         bench_macro_from_elem_small => gen_from_elem(VEC_SIZE as _),
         bench_pushpop => gen_pushpop(),
+        bench_retain_mut_half => gen_retain_mut_half(SPILLED_SIZE as _),
+        bench_retain_mut_half_small => gen_retain_mut_half(VEC_SIZE as _),
+        bench_retain_mut_all => gen_retain_mut_all(SPILLED_SIZE as _),
+        bench_retain_mut_all_small => gen_retain_mut_all(VEC_SIZE as _),
+        bench_retain_mut_none => gen_retain_mut_none(SPILLED_SIZE as _),
+        bench_retain_mut_none_small => gen_retain_mut_none(VEC_SIZE as _),
     }
 }
 
@@ -148,156 +157,269 @@ make_benches! {
         bench_macro_from_elem_vec => gen_from_elem(SPILLED_SIZE as _),
         bench_macro_from_elem_vec_small => gen_from_elem(VEC_SIZE as _),
         bench_pushpop_vec => gen_pushpop(),
+        bench_retain_mut_vec_half => gen_retain_mut_half(SPILLED_SIZE as _),
+        bench_retain_mut_vec_half_small => gen_retain_mut_half(VEC_SIZE as _),
+        bench_retain_mut_vec_all => gen_retain_mut_all(SPILLED_SIZE as _),
+        bench_retain_mut_vec_all_small => gen_retain_mut_all(VEC_SIZE as _),
+        bench_retain_mut_vec_none => gen_retain_mut_none(SPILLED_SIZE as _),
+        bench_retain_mut_vec_none_small => gen_retain_mut_none(VEC_SIZE as _),
     }
 }
 
 fn gen_push<V: Vector<u64>>(n: u64, b: &mut Bencher) {
     #[inline(never)]
     fn push_noinline<V: Vector<u64>>(vec: &mut V, x: u64) {
-        vec.push(x);
+        vec.push(black_box(x));
     }
 
     b.iter(|| {
+        let n = black_box(n);
         let mut vec = V::new();
         for x in 0..n {
             push_noinline(&mut vec, x);
         }
-        vec
+        black_box(vec)
     });
 }
 
 fn gen_insert_push<V: Vector<u64>>(n: u64, b: &mut Bencher) {
     #[inline(never)]
     fn insert_push_noinline<V: Vector<u64>>(vec: &mut V, x: u64) {
-        vec.insert(x as usize, x);
+        vec.insert(black_box(x) as usize, black_box(x));
     }
 
     b.iter(|| {
+        let n = black_box(n);
         let mut vec = V::new();
         for x in 0..n {
             insert_push_noinline(&mut vec, x);
         }
-        vec
+        black_box(vec)
     });
 }
 
 fn gen_insert<V: Vector<u64>>(n: u64, b: &mut Bencher) {
     #[inline(never)]
     fn insert_noinline<V: Vector<u64>>(vec: &mut V, p: usize, x: u64) {
-        vec.insert(p, x)
+        vec.insert(black_box(p), black_box(x))
     }
 
-    b.iter(|| {
-        let mut vec = V::new();
-        // Always insert at position 0 so that we are subject to shifts of
-        // many different lengths.
-        vec.push(0);
-        for x in 0..n {
-            insert_noinline(&mut vec, 0, x);
-        }
-        vec
-    });
+    b.iter_with_setup(
+        || {
+            let mut vec = V::new();
+            vec.push(0);
+            vec
+        },
+        |mut vec| {
+            let n = black_box(n);
+            for x in 0..n {
+                insert_noinline(&mut vec, 0, x);
+            }
+            vec
+        },
+    );
 }
 
 fn gen_remove<V: Vector<u64>>(n: usize, b: &mut Bencher) {
     #[inline(never)]
     fn remove_noinline<V: Vector<u64>>(vec: &mut V, p: usize) -> u64 {
-        vec.remove(p)
+        vec.remove(black_box(p))
     }
 
-    b.iter(|| {
-        let mut vec = V::from_elem(0, n as _);
-
-        for _ in 0..n {
-            remove_noinline(&mut vec, 0);
-        }
-    });
+    b.iter_with_setup(
+        || V::from_elem(0, black_box(n)),
+        |mut vec| {
+            for _ in 0..n {
+                black_box(remove_noinline(&mut vec, 0));
+            }
+            vec
+        },
+    );
 }
 
 fn gen_extend<V: Vector<u64>>(n: u64, b: &mut Bencher) {
     b.iter(|| {
+        let n = black_box(n);
         let mut vec = V::new();
         vec.extend(0..n);
-        vec
+        black_box(vec)
     });
 }
 
 fn gen_extend_filtered<V: Vector<u64>>(n: u64, b: &mut Bencher) {
     b.iter(|| {
         let mut vec = V::new();
-        vec.extend((0..n).filter(|i| i % 2 == 0));
-        vec
+        vec.extend((0..black_box(n)).filter(|i| black_box(*i) % 2 == 0));
+        black_box(vec)
     });
 }
 
 fn gen_from_iter<V: Vector<u64>>(n: u64, b: &mut Bencher) {
-    let v: Vec<u64> = (0..n).collect();
+    let v: Vec<u64> = (0..black_box(n)).collect();
     b.iter(|| {
-        let vec = V::from(&v);
-        vec
+        let vec = V::from(black_box(&v));
+        black_box(vec)
     });
 }
 
 fn gen_from_slice<V: Vector<u64>>(n: u64, b: &mut Bencher) {
-    let v: Vec<u64> = (0..n).collect();
+    let v: Vec<u64> = (0..black_box(n)).collect();
     b.iter(|| {
-        let vec = V::from_elems(&v);
-        vec
+        let vec = V::from_elems(black_box(&v));
+        black_box(vec)
     });
 }
 
 fn gen_extend_from_slice<V: Vector<u64>>(n: u64, b: &mut Bencher) {
-    let v: Vec<u64> = (0..n).collect();
+    let v: Vec<u64> = (0..black_box(n)).collect();
     b.iter(|| {
         let mut vec = V::new();
-        vec.extend_from_slice(&v);
-        vec
+        vec.extend_from_slice(black_box(&v));
+        black_box(vec)
     });
 }
 
 fn gen_pushpop<V: Vector<u64>>(b: &mut Bencher) {
     #[inline(never)]
     fn pushpop_noinline<V: Vector<u64>>(vec: &mut V, x: u64) -> Option<u64> {
-        vec.push(x);
+        vec.push(black_box(x));
         vec.pop()
     }
 
     b.iter(|| {
         let mut vec = V::new();
         for x in 0..SPILLED_SIZE as _ {
-            pushpop_noinline(&mut vec, x);
+            black_box(pushpop_noinline(&mut vec, x));
         }
-        vec
+        black_box(vec)
     });
 }
 
 fn gen_from_elem<V: Vector<u64>>(n: usize, b: &mut Bencher) {
     b.iter(|| {
-        let vec = V::from_elem(42, n);
-        vec
+        let n = black_box(n);
+        let vec = V::from_elem(black_box(42), n);
+        black_box(vec)
     });
 }
 
-#[bench]
-fn bench_macro_from_list(b: &mut Bencher) {
-    b.iter(|| {
-        let vec: SmallVec<u64, 16> = smallvec![
-            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 20, 24, 32, 36, 0x40, 0x80,
-            0x100, 0x200, 0x400, 0x800, 0x1000, 0x2000, 0x4000, 0x8000, 0x10000, 0x20000, 0x40000,
-            0x80000, 0x100000,
-        ];
-        vec
+fn gen_retain_mut_half<V: Vector<u64>>(n: usize, b: &mut Bencher) {
+    b.iter_with_setup(
+        || V::from_elem(16, black_box(n)),
+        |mut vec| {
+            vec.retain_mut(|x| black_box(*x) % 2 == 0);
+            vec
+        },
+    );
+}
+
+fn gen_retain_mut_all<V: Vector<u64>>(n: usize, b: &mut Bencher) {
+    b.iter_with_setup(
+        || V::from_elem(16, black_box(n)),
+        |mut vec| {
+            vec.retain_mut(|_| true);
+            vec
+        },
+    );
+}
+
+fn gen_retain_mut_none<V: Vector<u64>>(n: usize, b: &mut Bencher) {
+    b.iter_with_setup(
+        || V::from_elem(16, black_box(n)),
+        |mut vec| {
+            vec.retain_mut(|_| false);
+            vec
+        },
+    );
+}
+
+fn bench_macro_from_list(c: &mut Criterion) {
+    c.bench_function("bench_macro_from_list", |b| {
+        b.iter(|| {
+            let vec: SmallVec<u64, 16> = smallvec![
+                0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 20, 24, 32, 36, 0x40,
+                0x80, 0x100, 0x200, 0x400, 0x800, 0x1000, 0x2000, 0x4000, 0x8000, 0x10000, 0x20000,
+                0x40000, 0x80000, 0x100000,
+            ];
+            vec
+        })
     });
 }
 
-#[bench]
-fn bench_macro_from_list_vec(b: &mut Bencher) {
-    b.iter(|| {
-        let vec: Vec<u64> = vec![
-            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 20, 24, 32, 36, 0x40, 0x80,
-            0x100, 0x200, 0x400, 0x800, 0x1000, 0x2000, 0x4000, 0x8000, 0x10000, 0x20000, 0x40000,
-            0x80000, 0x100000,
-        ];
-        vec
+fn bench_macro_from_list_vec(c: &mut Criterion) {
+    c.bench_function("bench_macro_from_list_vec", |b| {
+        b.iter(|| {
+            let vec: Vec<u64> = vec![
+                0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 20, 24, 32, 36, 0x40,
+                0x80, 0x100, 0x200, 0x400, 0x800, 0x1000, 0x2000, 0x4000, 0x8000, 0x10000, 0x20000,
+                0x40000, 0x80000, 0x100000,
+            ];
+            vec
+        })
     });
 }
+
+criterion_group!(
+    name = benches;
+    config = Criterion::default()
+        .warm_up_time(Duration::from_millis(200))
+        .measurement_time(Duration::from_millis(700));
+    targets =
+    bench_push,
+    bench_push_small,
+    bench_insert_push,
+    bench_insert_push_small,
+    bench_insert,
+    bench_insert_small,
+    bench_remove,
+    bench_remove_small,
+    bench_extend,
+    bench_extend_small,
+    bench_extend_filtered,
+    bench_extend_filtered_small,
+    bench_from_iter,
+    bench_from_iter_small,
+    bench_from_slice,
+    bench_from_slice_small,
+    bench_extend_from_slice,
+    bench_extend_from_slice_small,
+    bench_macro_from_elem,
+    bench_macro_from_elem_small,
+    bench_pushpop,
+    bench_retain_mut_half,
+    bench_retain_mut_half_small,
+    bench_retain_mut_all,
+    bench_retain_mut_all_small,
+    bench_retain_mut_none,
+    bench_retain_mut_none_small,
+    bench_push_vec,
+    bench_push_vec_small,
+    bench_insert_push_vec,
+    bench_insert_push_vec_small,
+    bench_insert_vec,
+    bench_insert_vec_small,
+    bench_remove_vec,
+    bench_remove_vec_small,
+    bench_extend_vec,
+    bench_extend_vec_small,
+    bench_extend_vec_filtered,
+    bench_extend_vec_filtered_small,
+    bench_from_iter_vec,
+    bench_from_iter_vec_small,
+    bench_from_slice_vec,
+    bench_from_slice_vec_small,
+    bench_extend_from_slice_vec,
+    bench_extend_from_slice_vec_small,
+    bench_macro_from_elem_vec,
+    bench_macro_from_elem_vec_small,
+    bench_pushpop_vec,
+    bench_retain_mut_vec_half,
+    bench_retain_mut_vec_half_small,
+    bench_retain_mut_vec_all,
+    bench_retain_mut_vec_all_small,
+    bench_retain_mut_vec_none,
+    bench_retain_mut_vec_none_small,
+    bench_macro_from_list,
+    bench_macro_from_list_vec
+);
+criterion_main!(benches);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1277,18 +1277,17 @@ impl<T, const N: usize> SmallVec<T, N> {
 
     #[inline]
     pub fn pop(&mut self) -> Option<T> {
-        if self.is_empty() {
-            None
-        } else {
-            let len = self.len() - 1;
-            // SAFETY: len < old_len since this can't overflow, because the old length is
-            // non zero
-            unsafe { self.set_len(len) };
-            // SAFETY: this element was initialized and we just gave up ownership of it, so
-            // we can give it away
-            let value = unsafe { self.as_mut_ptr().add(len).read() };
-            Some(value)
+        let len = self.len();
+        if len == 0 {
+            return None;
         }
+        let new_len = len - 1;
+        // SAFETY: new_len < len since len is non-zero
+        unsafe { self.set_len(new_len) };
+        // SAFETY: this element was initialized and we just gave up ownership of it, so
+        // we can give it away
+        let value = unsafe { self.as_mut_ptr().add(new_len).read() };
+        Some(value)
     }
 
     #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1691,21 +1691,28 @@ impl<T, const N: usize> SmallVec<T, N> {
 
     #[inline]
     pub fn retain_mut<F: FnMut(&mut T) -> bool>(&mut self, mut f: F) {
-        let mut del = 0;
         let len = self.len();
+
+        if len == 0 {
+            // return early as hint to llvm, like what std does
+            return;
+        }
+
         let ptr = self.as_mut_ptr();
-        for i in 0..len {
+        let mut write_idx = 0;
+
+        for read_idx in 0..len {
             // SAFETY: all the pointers are in bounds
-            // `i - del` never overflows since `del <= i` is a maintained invariant
             unsafe {
-                if !f(&mut *ptr.add(i)) {
-                    del += 1;
-                } else if del > 0 {
-                    core::ptr::swap(ptr.add(i), ptr.add(i - del));
+                if f(&mut *ptr.add(read_idx)) {
+                    if write_idx < read_idx {
+                        core::ptr::swap(ptr.add(read_idx), ptr.add(write_idx));
+                    }
+                    write_idx += 1;
                 }
             }
         }
-        self.truncate(len - del);
+        self.truncate(write_idx);
     }
 
     #[inline]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1027,7 +1027,11 @@ fn collect_from_iter() {
     // A length of 3 is fine to trigger this bug under valgrind, but making the
     // vector 1 million elements makes it crash - which is much easier to
     // detect.
-    let iter = IterNoHint(std::iter::repeat(1u8).take(1_000_000));
+    #[cfg(miri)]
+    const ELEMENTS: usize = 1000;
+    #[cfg(not(miri))]
+    const ELEMENTS: usize = 1_000_000;
+    let iter = IterNoHint(std::iter::repeat(1u8).take(ELEMENTS));
 
     let _y: SmallVec<u8, 1> = SmallVec::from_iter(iter);
 }


### PR DESCRIPTION
This recover #396 changes which were rollback because of a MSRV problem with criterion.

* Reduces iterations of test under miri so it is runnable in reasonable time.
* Optimizes pop implementation
* Optimizes retain_mut implementation
* Adds criterion(0.4) benchmarks

I removed reserve optimizations as I am more experienced now and I can do better than that.
I'll send that and fix for #444 in separate PRs.