### PR TITLE
ci: build docs with all features on nightly

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,6 +57,10 @@ jobs:
         if: matrix.toolchain == 'nightly'
         run: cargo test --verbose --all-features
 
+      - name: Cargo doc all features
+        if: matrix.toolchain == 'nightly'
+        run: cargo doc --all-features
+
       - name: Cargo bench
         if: matrix.toolchain == 'nightly'
         run: cargo bench --verbose bench


### PR DESCRIPTION
## Summary
- build documentation with all features in the existing nightly toolchain job
- leave stable, beta, and MSRV jobs unchanged

## Validation
- `cargo +nightly doc --all-features`
- `git diff --check`

Closes #459