### PR TITLE
Add an "allocator-api2" feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c880a97d28a3681c0267bd29cff89621202715b065127cd445fa0f0fe0aa2880"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -500,6 +509,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 name = "smallvec"
 version = "2.0.0-alpha.12"
 dependencies = [
+ "allocator-api2",
  "bytes",
  "criterion",
  "malloc_size_of",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,16 +14,19 @@ documentation = "https://docs.rs/smallvec/"
 exclude = [".gitignore", "tests/", "scripts/", "fuzz/", "benches/", ".github/"]
 
 [features]
-std = []
+default = ["allocator-api2"]
+std = ["allocator-api2?/std"]
 specialization = []
 may_dangle = []
-serde = ["dep:serde_core"]
+serde = ["dep:serde_core", "allocator-api2?/serde"]
 internals = []
+allocator-api2 = ["dep:allocator-api2"]
 
 [dependencies]
 bytes = { version = "1", optional = true, default-features = false }
 serde_core = { version = "1.0.221", optional = true, default-features = false }
 malloc_size_of = { version = "0.1.1", optional = true, default-features = false }
+allocator-api2 = { version = "0.4.0", optional = true, default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
 serde_test = "1.0"

--- a/fuzz/fuzz_targets/smallvec_ops.rs
+++ b/fuzz/fuzz_targets/smallvec_ops.rs
@@ -58,7 +58,7 @@ fn do_test<const N: usize>(data: &[u8]) -> SmallVec<u8, N> {
             5 => {
                 v.pop();
             }
-            6 => v.grow(next_usize!(bytes) + v.len()),
+            6 => v.reserve_exact(next_usize!(bytes)),
             7 => {
                 if v.len() < CAP_GROWTH {
                     v.reserve(next_usize!(bytes))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2285,7 +2285,7 @@ impl<T, const N: usize, A: Allocator> SmallVec<T, N, A> {
     }
 }
 
-impl<T: Clone, const N: usize, A: Allocator + Clone> SmallVec<T, N, A> {
+impl<T: Clone, const N: usize, A: Allocator> SmallVec<T, N, A> {
     /// Creates a [`SmallVec`] value from the slice `slice` with the specified
     /// allocator.
     pub fn from_slice_in(slice: &[T], alloc: A) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,7 @@
 #![cfg_attr(feature = "specialization", allow(incomplete_features))]
 #![cfg_attr(feature = "specialization", feature(specialization, trusted_len))]
 #![cfg_attr(feature = "may_dangle", feature(dropck_eyepatch))]
+#![cfg_attr(not(feature = "allocator-api2"), feature(allocator_api))]
 
 #[doc(hidden)]
 pub extern crate alloc;
@@ -69,10 +70,13 @@ mod rawsmallvec;
 #[cfg(test)]
 mod tests;
 
-use alloc::alloc::Layout;
+#[cfg(not(feature = "allocator-api2"))]
+use alloc::alloc::{AllocError, Allocator, Global, Layout};
 use alloc::boxed::Box;
 use alloc::vec;
 use alloc::vec::Vec;
+#[cfg(feature = "allocator-api2")]
+use allocator_api2::alloc::{AllocError, Allocator, Global, Layout};
 #[cfg(feature = "bytes")]
 use bytes::{buf::UninitSlice, BufMut};
 use core::borrow::Borrow;
@@ -90,9 +94,9 @@ use core::ptr::NonNull;
 #[cfg(feature = "malloc_size_of")]
 use malloc_size_of::{MallocShallowSizeOf, MallocSizeOf, MallocSizeOfOps};
 #[cfg(feature = "internals")]
-pub use rawsmallvec::RawSmallVec;
+pub use rawsmallvec::{RawSmallVec, RawSmallVecUnion};
 #[cfg(not(feature = "internals"))]
-use rawsmallvec::RawSmallVec;
+use rawsmallvec::{RawSmallVec, RawSmallVecUnion};
 #[cfg(feature = "serde")]
 use serde_core::{
     de::{Deserialize, Deserializer, SeqAccess, Visitor},
@@ -100,11 +104,6 @@ use serde_core::{
 };
 #[cfg(feature = "std")]
 use std::io;
-
-#[cfg(feature = "allocator-api2")]
-use allocator_api2::{*, alloc::*};
-#[cfg(not(feature = "allocator-api2"))]
-use core::alloc::*;
 
 /// Error type for APIs with fallible heap allocation
 #[derive(Debug)]
@@ -134,10 +133,37 @@ fn infallible<T>(result: Result<T, CollectionAllocErr>) -> T {
     }
 }
 
+/// Creates a [`Layout`] values for arrays of length `n`
+/// for a given type without checking preconditions.
+///
+/// # Safety
+///
+/// The caller must ensure that an array of length `n` results
+/// in a valid layout.
+#[inline(always)]
+const unsafe fn array_layout_unchecked<T>(n: usize) -> Layout {
+    // SAFETY: The caller ensures that the an array of length `n` is possible
+    // which means that the multiplication can't overflow.
+    // The value returned by `align_of` will fulfill the safety conditions for
+    // `Layout::from_size_align_unchecked`.
+    unsafe { Layout::from_size_align_unchecked(size_of::<T>().unchecked_mul(n), align_of::<T>()) }
+}
+
 /// Helper function to check if a type is a ZST.
 #[inline]
 const fn is_zst<T>() -> bool {
     const { size_of::<T>() == 0 }
+}
+
+#[inline(always)]
+const fn inline_size<T, const N: usize>() -> usize {
+    const {
+        if is_zst::<T>() {
+            usize::MAX
+        } else {
+            N
+        }
+    }
 }
 
 #[inline]
@@ -175,19 +201,14 @@ where
     core::ops::Range { start, end }
 }
 
-impl<T, const N: usize> RawSmallVec<T, N> {
-    const IS_ZST: bool = is_zst::<T>();
-
-    #[inline]
-    const fn new() -> Self {
-        Self::new_inline(MaybeUninit::uninit())
-    }
+impl<T, const N: usize> RawSmallVecUnion<T, N> {
     #[inline]
     const fn new_inline(inline: MaybeUninit<[T; N]>) -> Self {
         Self {
             inline: ManuallyDrop::new(inline),
         }
     }
+
     #[inline]
     const fn new_heap(ptr: NonNull<T>, capacity: usize) -> Self {
         Self {
@@ -211,73 +232,328 @@ impl<T, const N: usize> RawSmallVec<T, N> {
 
     /// # Safety
     ///
-    /// The vector must be on the heap
+    /// The vector must be on the heap.
     #[inline]
     const unsafe fn as_ptr_heap(&self) -> *const T {
-        self.heap.0.as_ptr()
+        // SAFETY: Safety conditions are identical.
+        unsafe { self.heap.0.as_ptr() }
     }
 
     /// # Safety
     ///
-    /// The vector must be on the heap
+    /// The vector must be on the heap.
     #[inline]
     const unsafe fn as_mut_ptr_heap(&mut self) -> *mut T {
-        self.heap.0.as_ptr()
+        // SAFETY: Safety conditions are identical.
+        unsafe { self.heap.0.as_ptr() }
+    }
+}
+
+impl<T, const N: usize> RawSmallVec<T, N> {
+    #[inline]
+    pub const fn new() -> Self {
+        Self::new_in(Global)
     }
 
+    #[inline]
+    pub const fn new_inline(inline: MaybeUninit<[T; N]>) -> Self {
+        Self::new_inline_in(inline, Global)
+    }
+
+    #[inline]
+    pub const fn new_heap(ptr: NonNull<T>, capacity: usize) -> Self {
+        Self::new_heap_in(ptr, capacity, Global)
+    }
+
+    #[inline]
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self::with_capacity_in(capacity, Global)
+    }
+}
+
+impl<T, const N: usize, A: Allocator> RawSmallVec<T, N, A> {
+    const IS_ZST: bool = is_zst::<T>();
+
+    /// Turn a generic allocation error returned by a parametric allocator into
+    /// a [`CollectionAllocErr`].
+    #[inline(always)]
+    fn handle_alloc_error<U>(
+        r: Result<U, AllocError>,
+        layout: Layout,
+    ) -> Result<U, CollectionAllocErr> {
+        r.map_err(|_| CollectionAllocErr::AllocErr { layout })
+    }
+
+    #[inline]
+    const fn new_in(allocator: A) -> Self {
+        Self::new_inline_in(MaybeUninit::uninit(), allocator)
+    }
+
+    #[inline]
+    const fn new_inline_in(inline: MaybeUninit<[T; N]>, allocator: A) -> Self {
+        Self {
+            inner: RawSmallVecUnion::new_inline(inline),
+            allocator,
+        }
+    }
+
+    #[inline]
+    const fn new_heap_in(ptr: NonNull<T>, capacity: usize, allocator: A) -> Self {
+        Self {
+            inner: RawSmallVecUnion::new_heap(ptr, capacity),
+            allocator,
+        }
+    }
+
+    #[inline]
+    fn with_capacity_in(capacity: usize, allocator: A) -> Self {
+        infallible(Self::try_with_capacity_in(capacity, allocator))
+    }
+
+    #[inline]
+    fn try_with_capacity_in(capacity: usize, allocator: A) -> Result<Self, CollectionAllocErr> {
+        if capacity <= const { inline_size::<T, N>() } {
+            Ok(Self::new_inline_in(MaybeUninit::uninit(), allocator))
+        } else {
+            let layout =
+                Layout::array::<T>(capacity).map_err(|_| CollectionAllocErr::CapacityOverflow)?;
+            let ptr = Self::handle_alloc_error(allocator.allocate(layout), layout)?;
+            let inner = RawSmallVecUnion {
+                heap: (ptr.cast(), capacity),
+            };
+            Ok(Self { inner, allocator })
+        }
+    }
+
+    /// Gets a pointer to the contents of the vector, under the assumption
+    /// that the content is stored inline.
+    #[inline]
+    pub const fn as_ptr_inline(&self) -> *const T {
+        self.inner.as_ptr_inline()
+    }
+
+    /// Gets a pointer to the contents of the vector, under the assumption
+    /// that the content is stored inline.
+    #[inline]
+    pub const fn as_mut_ptr_inline(&mut self) -> *mut T {
+        self.inner.as_mut_ptr_inline()
+    }
+
+    /// Gets a pointer to the contents of the vector, under the assumption
+    /// that the content is stored on the heap.
+    ///
     /// # Safety
     ///
-    /// `new_capacity` must be non zero, and greater or equal to the length.
-    /// T must not be a ZST.
-    unsafe fn try_grow_raw(
+    /// The vector must be on the heap.
+    #[inline]
+    pub const unsafe fn as_ptr_heap(&self) -> *const T {
+        // SAFETY: The safety requirements are identical.
+        unsafe { self.inner.as_ptr_heap() }
+    }
+
+    /// Gets a pointer to the contents of the vector, under the assumption
+    /// that the content is stored on the heap.
+    ///
+    /// # Safety
+    ///
+    /// The vector must be on the heap.
+    #[inline]
+    pub const unsafe fn as_mut_ptr_heap(&mut self) -> *mut T {
+        // SAFETY: The safety requirements are identical.
+        unsafe { self.inner.as_mut_ptr_heap() }
+    }
+
+    /// Returns `true` if the elements are stored on the heap, and `false`
+    /// otherwise.
+    ///
+    /// # Safety
+    ///
+    /// The way elements are stored in `self` must correspond to the tag in
+    /// `len`.
+    unsafe fn try_reserve(
         &mut self,
         len: TaggedLen<T>,
-        new_capacity: usize,
-    ) -> Result<(), CollectionAllocErr> {
-        use alloc::alloc::{alloc, realloc};
+        additional: usize,
+    ) -> Result<bool, CollectionAllocErr> {
         debug_assert!(!Self::IS_ZST);
-        debug_assert!(new_capacity > 0);
-        debug_assert!(new_capacity >= len.value());
 
-        let was_on_heap = len.on_heap();
-        let ptr = if was_on_heap {
-            self.as_mut_ptr_heap()
-        } else {
-            self.as_mut_ptr_inline()
-        };
+        let on_heap = len.on_heap();
         let len = len.value();
 
-        let new_layout =
-            Layout::array::<T>(new_capacity).map_err(|_| CollectionAllocErr::CapacityOverflow)?;
-        if new_layout.size() > isize::MAX as usize {
-            return Err(CollectionAllocErr::CapacityOverflow);
+        if additional == 0 {
+            return Ok(on_heap);
         }
 
-        let new_ptr = if !was_on_heap {
-            // get a fresh allocation
-            let new_ptr = alloc(new_layout) as *mut T; // `new_layout` has nonzero size.
-            let new_ptr =
-                NonNull::new(new_ptr).ok_or(CollectionAllocErr::AllocErr { layout: new_layout })?;
-            copy_nonoverlapping(ptr, new_ptr.as_ptr(), len);
-            new_ptr
+        let new_capacity = len
+            .checked_add(additional)
+            .ok_or(CollectionAllocErr::CapacityOverflow)?;
+
+        if on_heap {
+            // SAFETY: The caller ensures that the tag corresponds to the
+            // way in which data is stored.
+            let (old_ptr, old_capacity) = unsafe { self.inner.heap };
+
+            // Nothing needs to be done if the capacity is already sufficient.
+            if old_capacity >= new_capacity {
+                return Ok(true);
+            }
+
+            // Ensure capacity growth is exponential.
+            let new_capacity = new_capacity.max(2 * old_capacity);
+
+            // SAFETY: The stored capacity always corresponds to a valid layout.
+            let old_layout = unsafe { array_layout_unchecked::<T>(old_capacity) };
+
+            let new_layout = Layout::array::<T>(new_capacity)
+                .map_err(|_| CollectionAllocErr::CapacityOverflow)?;
+            let ptr = Self::handle_alloc_error(
+                self.allocator.grow(old_ptr.cast(), old_layout, new_layout),
+                new_layout,
+            )?;
+
+            self.inner = RawSmallVecUnion::new_heap(ptr.cast(), new_capacity);
+            Ok(true)
+        } else if new_capacity > const { inline_size::<T, N>() } {
+            // Ensure capacity growth is exponential.
+            let new_capacity = (2 * N).max(new_capacity);
+
+            let layout = Layout::array::<T>(new_capacity)
+                .map_err(|_| CollectionAllocErr::CapacityOverflow)?;
+            let ptr = Self::handle_alloc_error(self.allocator.allocate(layout), layout)?;
+
+            // SAFETY: The pointer returned by `allocate` is valid and its own memory
+            // region.
+            unsafe {
+                copy_nonoverlapping(self.as_mut_ptr_inline(), ptr.cast().as_ptr(), len);
+            }
+
+            self.inner = RawSmallVecUnion::new_heap(ptr.cast(), new_capacity);
+            Ok(true)
         } else {
-            // use realloc
+            Ok(on_heap)
+        }
+    }
 
-            // this can't overflow since we already constructed an equivalent layout during
-            // the previous allocation
-            let old_layout =
-                Layout::from_size_align_unchecked(self.heap.1 * size_of::<T>(), align_of::<T>());
+    /// Returns `true` if the elements are stored on the heap, and `false`
+    /// otherwise.
+    ///
+    /// # Safety
+    ///
+    /// The way elements are stored in `self` must correspond to the tag in
+    /// `len`.
+    unsafe fn try_reserve_exact(
+        &mut self,
+        len: TaggedLen<T>,
+        additional: usize,
+    ) -> Result<bool, CollectionAllocErr> {
+        debug_assert!(!is_zst::<T>());
 
-            // SAFETY: ptr was allocated with this allocator
-            // old_layout is the same as the layout used to allocate the previous memory
-            // block new_layout.size() is greater than zero
-            // does not overflow when rounded up to alignment. since it was constructed
-            // with Layout::array
-            let new_ptr = realloc(ptr as *mut u8, old_layout, new_layout.size()) as *mut T;
-            NonNull::new(new_ptr).ok_or(CollectionAllocErr::AllocErr { layout: new_layout })?
-        };
-        *self = Self::new_heap(new_ptr, new_capacity);
-        Ok(())
+        let on_heap = len.on_heap();
+        let len = len.value();
+
+        if additional == 0 {
+            return Ok(on_heap);
+        }
+
+        let new_capacity = len
+            .checked_add(additional)
+            .ok_or(CollectionAllocErr::CapacityOverflow)?;
+
+        if on_heap {
+            // SAFETY: The caller ensures that the tag corresponds to the
+            // way in which data is stored.
+            let (old_ptr, old_capacity) = unsafe { self.inner.heap };
+
+            // Nothing needs to be done if the capacity is already sufficient.
+            if old_capacity >= new_capacity {
+                return Ok(true);
+            }
+
+            // SAFETY: The stored capacity always corresponds to a valid layout.
+            let old_layout = unsafe { array_layout_unchecked::<T>(old_capacity) };
+
+            let new_layout = Layout::array::<T>(new_capacity)
+                .map_err(|_| CollectionAllocErr::CapacityOverflow)?;
+            let ptr = Self::handle_alloc_error(
+                self.allocator.grow(old_ptr.cast(), old_layout, new_layout),
+                new_layout,
+            )?;
+
+            self.inner = RawSmallVecUnion::new_heap(ptr.cast(), new_capacity);
+
+            Ok(true)
+        } else if new_capacity > const { inline_size::<T, N>() } {
+            let layout = Layout::array::<T>(new_capacity)
+                .map_err(|_| CollectionAllocErr::CapacityOverflow)?;
+            let ptr = Self::handle_alloc_error(self.allocator.allocate(layout), layout)?;
+
+            // SAFETY: The pointer returned by `allocate` is valid and its own memory
+            // region.
+            unsafe {
+                copy_nonoverlapping(self.as_mut_ptr_inline(), ptr.cast().as_ptr(), len);
+            }
+
+            self.inner = RawSmallVecUnion::new_heap(ptr.cast(), new_capacity);
+
+            Ok(true)
+        } else {
+            Ok(on_heap)
+        }
+    }
+
+    /// Returns `true` if the elements are still stored on the heap, and `false`
+    /// otherwise.
+    ///
+    /// # Safety
+    ///
+    /// The way elements are stored in `self` must correspond to `on_heap`.
+    unsafe fn shrink_to_fit(
+        &mut self,
+        on_heap: bool,
+        cap: usize,
+    ) -> Result<bool, CollectionAllocErr> {
+        debug_assert!(!is_zst::<T>());
+
+        if on_heap {
+            // SAFETY: The caller ensures that the tag corresponds to the
+            // way in which data is stored.
+            let (old_ptr, old_capacity) = unsafe { self.inner.heap };
+
+            // SAFETY: The stored capacity corresponds always to a valid layout.
+            let layout = unsafe { array_layout_unchecked::<T>(old_capacity) };
+
+            if cap <= N {
+                self.inner = RawSmallVecUnion::new_inline(MaybeUninit::uninit());
+
+                // SAFETY: The memory regions don't overlap because one pointer is recently
+                // created inline storage. By taking the minimum value of both
+                // capabilities, the copying will only touch valid memory.
+                unsafe {
+                    let count = cap.min(old_capacity);
+                    copy_nonoverlapping(old_ptr.cast().as_ptr(), self.as_mut_ptr_inline(), count);
+                }
+
+                self.allocator.deallocate(old_ptr.cast(), layout);
+
+                Ok(false)
+            } else if cap < old_capacity {
+                // SAFETY: The new capacity is smaller than the old capacity,
+                // and it is already possible to construct a valid layout with the old capacity.
+                let new_layout = unsafe { array_layout_unchecked::<T>(cap) };
+
+                let ptr = Self::handle_alloc_error(
+                    self.allocator.shrink(old_ptr.cast(), layout, new_layout),
+                    new_layout,
+                )?;
+                self.inner = RawSmallVecUnion::new_heap(ptr.cast(), cap);
+
+                Ok(true)
+            } else {
+                Ok(true)
+            }
+        } else {
+            Ok(on_heap)
+        }
     }
 }
 
@@ -849,11 +1125,12 @@ impl<T, const N: usize> SmallVec<T, N> {
 
     #[inline]
     pub fn with_capacity(capacity: usize) -> Self {
-        let mut this = Self::new();
-        if capacity > Self::inline_size() {
-            this.grow(capacity);
+        let on_heap = capacity > const { inline_size::<T, N>() };
+        Self {
+            len: TaggedLen::new(0, on_heap),
+            raw: RawSmallVec::with_capacity(capacity),
+            _marker: PhantomData,
         }
-        this
     }
 
     #[inline]
@@ -986,7 +1263,7 @@ impl<T, const N: usize> SmallVec<T, N> {
     ///
     /// # Safety
     ///
-    /// The active union member must be the self.raw.heap
+    /// The active union member must be the self.raw.inner.heap
     #[inline]
     unsafe fn set_on_heap(&mut self) {
         self.len = TaggedLen::new(self.len(), true);
@@ -996,7 +1273,7 @@ impl<T, const N: usize> SmallVec<T, N> {
     ///
     /// # Safety
     ///
-    /// The active union member must be the self.raw.inline
+    /// The active union member must be the self.raw.inner.inline
     #[inline]
     unsafe fn set_inline(&mut self) {
         self.len = TaggedLen::new(self.len(), false);
@@ -1042,8 +1319,8 @@ impl<T, const N: usize> SmallVec<T, N> {
     #[inline]
     pub const fn capacity(&self) -> usize {
         if self.len.on_heap() {
-            // SAFETY: raw.heap is active
-            unsafe { self.raw.heap.1 }
+            // SAFETY: raw.inner.heap is active
+            unsafe { self.raw.inner.heap.1 }
         } else {
             Self::inline_size()
         }
@@ -1326,161 +1603,86 @@ impl<T, const N: usize> SmallVec<T, N> {
     }
 
     #[inline]
-    pub fn grow(&mut self, new_capacity: usize) {
-        infallible(self.try_grow(new_capacity));
-    }
-
-    #[cold]
-    pub fn try_grow(&mut self, new_capacity: usize) -> Result<(), CollectionAllocErr> {
-        if Self::IS_ZST {
-            return Ok(());
-        }
-
-        let len = self.len();
-        assert!(new_capacity >= len);
-
-        if new_capacity > Self::inline_size() {
-            // SAFETY: we checked all the preconditions
-            let result = unsafe { self.raw.try_grow_raw(self.len, new_capacity) };
-
-            if result.is_ok() {
-                // SAFETY: the allocation succeeded, so self.raw.heap is now active
-                unsafe { self.set_on_heap() };
-            }
-            result
-        } else {
-            // new_capacity <= Self::inline_size()
-            if self.spilled() {
-                unsafe {
-                    // SAFETY: heap member is active
-                    let (ptr, old_cap) = self.raw.heap;
-                    // inline member is now active
-
-                    // SAFETY: len <= new_capacity <= Self::inline_size()
-                    // so the copy is within bounds of the inline member
-                    copy_nonoverlapping(ptr.as_ptr(), self.raw.as_mut_ptr_inline(), len);
-                    drop(DropDealloc {
-                        ptr: ptr.cast(),
-                        size_bytes: old_cap * size_of::<T>(),
-                        align: align_of::<T>(),
-                    });
-                    self.set_inline();
-                }
-            }
-            Ok(())
-        }
-    }
-
-    #[inline]
     pub fn reserve(&mut self, additional: usize) {
-        // can't overflow since len <= capacity
-        if additional > self.capacity() - self.len() {
-            let new_capacity = infallible(
-                self.len()
-                    .checked_add(additional)
-                    .and_then(usize::checked_next_power_of_two)
-                    .ok_or(CollectionAllocErr::CapacityOverflow),
-            );
-            self.grow(new_capacity);
-        }
+        infallible(self.try_reserve(additional));
     }
 
     #[inline]
     pub fn try_reserve(&mut self, additional: usize) -> Result<(), CollectionAllocErr> {
-        if additional > self.capacity() - self.len() {
-            let new_capacity = self
-                .len()
-                .checked_add(additional)
-                .and_then(usize::checked_next_power_of_two)
-                .ok_or(CollectionAllocErr::CapacityOverflow)?;
-            self.try_grow(new_capacity)
-        } else {
-            Ok(())
+        if Self::IS_ZST {
+            return Ok(());
         }
+
+        // SAFETY: The tag inside the length of the vector corresponds to the way
+        // elements are stored inside the vector. The same goes for the return value
+        // of the function.
+        unsafe {
+            let on_heap = self.raw.try_reserve(self.len, additional)?;
+            if on_heap {
+                self.set_on_heap();
+            } else {
+                self.set_inline();
+            }
+        };
+
+        Ok(())
     }
 
     #[inline]
     pub fn reserve_exact(&mut self, additional: usize) {
-        // can't overflow since len <= capacity
-        if additional > self.capacity() - self.len() {
-            let new_capacity = infallible(
-                self.len()
-                    .checked_add(additional)
-                    .ok_or(CollectionAllocErr::CapacityOverflow),
-            );
-            self.grow(new_capacity);
-        }
+        infallible(self.try_reserve_exact(additional));
     }
 
     #[inline]
     pub fn try_reserve_exact(&mut self, additional: usize) -> Result<(), CollectionAllocErr> {
-        if additional > self.capacity() - self.len() {
-            let new_capacity = self
-                .len()
-                .checked_add(additional)
-                .ok_or(CollectionAllocErr::CapacityOverflow)?;
-            self.try_grow(new_capacity)
-        } else {
-            Ok(())
+        if Self::IS_ZST {
+            return Ok(());
         }
+
+        // SAFETY: The tag inside the length of the vector corresponds to the way
+        // elements are stored inside the vector. The same goes for the return value
+        // of the function.
+        unsafe {
+            let on_heap = self.raw.try_reserve_exact(self.len, additional)?;
+            if on_heap {
+                self.set_on_heap();
+            } else {
+                self.set_inline();
+            }
+        };
+
+        Ok(())
     }
 
     #[inline]
     pub fn shrink_to_fit(&mut self) {
-        if !self.spilled() {
+        if Self::IS_ZST {
             return;
         }
+
         let len = self.len();
-        if len <= Self::inline_size() {
-            // SAFETY: self.spilled() is true, so we're on the heap
-            unsafe {
-                let (ptr, capacity) = self.raw.heap;
-                self.raw = RawSmallVec::new_inline(MaybeUninit::uninit());
-                copy_nonoverlapping(ptr.as_ptr(), self.raw.as_mut_ptr_inline(), len);
-                self.set_inline();
-                alloc::alloc::dealloc(
-                    ptr.cast().as_ptr(),
-                    Layout::from_size_align_unchecked(capacity * size_of::<T>(), align_of::<T>()),
-                );
-            }
-        } else if len < self.capacity() {
-            // SAFETY: len > Self::inline_size() >= 0
-            // so new capacity is non zero, it is equal to the length
-            // T can't be a ZST because SmallVec<ZST, N> is never spilled.
-            unsafe { infallible(self.raw.try_grow_raw(self.len, len)) };
-        }
+        let on_heap = self.spilled();
+
+        // SAFETY: The tag inside the length of the vector corresponds to the way
+        // elements are stored inside the vector.
+        let on_heap = unsafe { infallible(self.raw.shrink_to_fit(on_heap, len)) };
+        self.len = TaggedLen::new(len, on_heap);
     }
 
     #[inline]
     pub fn shrink_to(&mut self, min_capacity: usize) {
-        if !self.spilled() {
+        if Self::IS_ZST {
             return;
         }
-        if self.capacity() > min_capacity {
-            let len = self.len();
-            let target = core::cmp::max(len, min_capacity);
-            if target <= Self::inline_size() {
-                // SAFETY: self.spilled() is true, so we're on the heap
-                unsafe {
-                    let (ptr, capacity) = self.raw.heap;
-                    self.raw = RawSmallVec::new_inline(MaybeUninit::uninit());
-                    copy_nonoverlapping(ptr.as_ptr(), self.raw.as_mut_ptr_inline(), len);
-                    self.set_inline();
-                    alloc::alloc::dealloc(
-                        ptr.cast().as_ptr(),
-                        Layout::from_size_align_unchecked(
-                            capacity * size_of::<T>(),
-                            align_of::<T>(),
-                        ),
-                    );
-                }
-            } else if target < self.capacity() {
-                // SAFETY: len > Self::inline_size() >= 0
-                // so new capacity is non zero, it is equal to the length
-                // T can't be a ZST because SmallVec<ZST, N> is never spilled.
-                unsafe { infallible(self.raw.try_grow_raw(self.len, target)) };
-            }
-        }
+
+        let len = self.len();
+        let min_capacity = len.max(min_capacity);
+        let on_heap = self.spilled();
+
+        // SAFETY: The tag inside the length of the vector corresponds to the way
+        // elements are stored inside the vector.
+        let on_heap = unsafe { infallible(self.raw.shrink_to_fit(on_heap, min_capacity)) };
+        self.len = TaggedLen::new(len, on_heap);
     }
 
     #[inline]
@@ -1661,7 +1863,7 @@ impl<T, const N: usize> SmallVec<T, N> {
             // - the first `len` entries are proper `T`-values
             // - the allocation is not larger than `isize::MAX`
             unsafe {
-                let (ptr, cap) = this.raw.heap;
+                let (ptr, cap) = this.raw.inner.heap;
                 Vec::from_raw_parts(ptr.as_ptr(), len, cap)
             }
         }
@@ -2104,7 +2306,7 @@ impl<T, const N: usize> Drop for IntoIter<T, N> {
             let end = self.end.value();
             let ptr = self.as_mut_ptr();
             let _drop_dealloc = if on_heap {
-                let capacity = self.raw.heap.1;
+                let capacity = self.raw.inner.heap.1;
                 Some(DropDealloc {
                     ptr: NonNull::new_unchecked(ptr as *mut u8),
                     size_bytes: capacity * size_of::<T>(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1504,9 +1504,12 @@ impl<T, const N: usize> SmallVec<T, N> {
             }
         } else {
             // FIXME: Use `into_parts` once it is stable.
-            let (ptr, len, cap) = vec.into_raw_parts();
+            // `into_raw_parts` cannot be use here because of the crates MSRV.
+            let mut vec = ManuallyDrop::new(vec);
+            let len = vec.len();
+            let cap = vec.capacity();
             // SAFETY: The pointer of a `Vec` is never null.
-            let ptr = unsafe { NonNull::new_unchecked(ptr) };
+            let ptr = unsafe { NonNull::new_unchecked(vec.as_mut_ptr()) };
 
             Self {
                 len: TaggedLen::new(len, true),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,6 +101,11 @@ use serde_core::{
 #[cfg(feature = "std")]
 use std::io;
 
+#[cfg(feature = "allocator-api2")]
+use allocator_api2::{*, alloc::*};
+#[cfg(not(feature = "allocator-api2"))]
+use core::alloc::*;
+
 /// Error type for APIs with fallible heap allocation
 #[derive(Debug)]
 pub enum CollectionAllocErr {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,10 @@ use alloc::boxed::Box;
 use alloc::vec;
 use alloc::vec::Vec;
 #[cfg(feature = "allocator-api2")]
-use allocator_api2::alloc::{AllocError, Allocator, Global, Layout};
+use allocator_api2::{
+    alloc::{AllocError, Allocator, Global, Layout},
+    SliceExt,
+};
 #[cfg(feature = "bytes")]
 use bytes::{buf::UninitSlice, BufMut};
 use core::borrow::Borrow;
@@ -619,9 +622,9 @@ impl<T> TaggedLen<T> {
 }
 
 #[repr(C)]
-pub struct SmallVec<T, const N: usize> {
+pub struct SmallVec<T, const N: usize, A: Allocator = Global> {
     len: TaggedLen<T>,
-    raw: RawSmallVec<T, N>,
+    raw: RawSmallVec<T, N, A>,
     _marker: PhantomData<T>,
 }
 
@@ -641,7 +644,7 @@ impl<T, const N: usize> Default for SmallVec<T, N> {
 /// Returned from [`SmallVec::drain`][1].
 ///
 /// [1]: struct.SmallVec.html#method.drain
-pub struct Drain<'a, T: 'a, const N: usize> {
+pub struct Drain<'a, T: 'a, const N: usize, A: Allocator = Global> {
     // `vec` points to a valid object within its lifetime.
     // This is ensured by the fact that we're holding an iterator to its items.
     //
@@ -652,10 +655,10 @@ pub struct Drain<'a, T: 'a, const N: usize> {
     tail_start: usize,
     tail_len: usize,
     iter: core::slice::Iter<'a, T>,
-    vec: core::ptr::NonNull<SmallVec<T, N>>,
+    vec: core::ptr::NonNull<SmallVec<T, N, A>>,
 }
 
-impl<'a, T: 'a, const N: usize> Iterator for Drain<'a, T, N> {
+impl<'a, T: 'a, const N: usize, A: Allocator> Iterator for Drain<'a, T, N, A> {
     type Item = T;
 
     #[inline]
@@ -673,7 +676,7 @@ impl<'a, T: 'a, const N: usize> Iterator for Drain<'a, T, N> {
     }
 }
 
-impl<'a, T: 'a, const N: usize> DoubleEndedIterator for Drain<'a, T, N> {
+impl<'a, T: 'a, const N: usize, A: Allocator> DoubleEndedIterator for Drain<'a, T, N, A> {
     #[inline]
     fn next_back(&mut self) -> Option<T> {
         // SAFETY: see above
@@ -683,21 +686,21 @@ impl<'a, T: 'a, const N: usize> DoubleEndedIterator for Drain<'a, T, N> {
     }
 }
 
-impl<T, const N: usize> ExactSizeIterator for Drain<'_, T, N> {
+impl<T, const N: usize, A: Allocator> ExactSizeIterator for Drain<'_, T, N, A> {
     #[inline]
     fn len(&self) -> usize {
         self.iter.len()
     }
 }
 
-impl<T, const N: usize> core::iter::FusedIterator for Drain<'_, T, N> {}
+impl<T, const N: usize, A: Allocator> core::iter::FusedIterator for Drain<'_, T, N, A> {}
 
-impl<'a, T: 'a, const N: usize> Drop for Drain<'a, T, N> {
+impl<'a, T: 'a, const N: usize, A: Allocator> Drop for Drain<'a, T, N, A> {
     fn drop(&mut self) {
         /// Moves back the un-`Drain`ed elements to restore the original `Vec`.
-        struct DropGuard<'r, 'a, T, const N: usize>(&'r mut Drain<'a, T, N>);
+        struct DropGuard<'r, 'a, T, const N: usize, A: Allocator>(&'r mut Drain<'a, T, N, A>);
 
-        impl<'r, 'a, T, const N: usize> Drop for DropGuard<'r, 'a, T, N> {
+        impl<'r, 'a, T, const N: usize, A: Allocator> Drop for DropGuard<'r, 'a, T, N, A> {
             fn drop(&mut self) {
                 if self.0.tail_len > 0 {
                     unsafe {
@@ -722,7 +725,7 @@ impl<'a, T: 'a, const N: usize> Drop for Drain<'a, T, N> {
 
         let mut vec = self.vec;
 
-        if SmallVec::<T, N>::IS_ZST {
+        if SmallVec::<T, N, A>::IS_ZST {
             // ZSTs have no identity, so we don't need to move them around, we only need to
             // drop the correct amount. this can be achieved by manipulating the
             // Vec length instead of moving values out from `iter`.
@@ -766,7 +769,7 @@ impl<'a, T: 'a, const N: usize> Drop for Drain<'a, T, N> {
     }
 }
 
-impl<T, const N: usize> Drain<'_, T, N> {
+impl<T, const N: usize, A: Allocator> Drain<'_, T, N, A> {
     #[must_use]
     pub fn as_slice(&self) -> &[T] {
         self.iter.as_slice()
@@ -827,11 +830,11 @@ impl<T, const N: usize> Drain<'_, T, N> {
 /// Returned from [`SmallVec::extract_if`][1].
 ///
 /// [1]: struct.SmallVec.html#method.extract_if
-pub struct ExtractIf<'a, T, const N: usize, F>
+pub struct ExtractIf<'a, T, const N: usize, F, A: Allocator = Global>
 where
     F: FnMut(&mut T) -> bool,
 {
-    vec: &'a mut SmallVec<T, N>,
+    vec: &'a mut SmallVec<T, N, A>,
     /// The index of the item that will be inspected by the next call to `next`.
     idx: usize,
     /// Elements at and beyond this point will be retained. Must be equal or
@@ -845,7 +848,7 @@ where
     pred: F,
 }
 
-impl<T, const N: usize, F> core::fmt::Debug for ExtractIf<'_, T, N, F>
+impl<T, const N: usize, F, A: Allocator> core::fmt::Debug for ExtractIf<'_, T, N, F, A>
 where
     F: FnMut(&mut T) -> bool,
     T: core::fmt::Debug,
@@ -857,7 +860,7 @@ where
     }
 }
 
-impl<T, F, const N: usize> Iterator for ExtractIf<'_, T, N, F>
+impl<T, F, const N: usize, A: Allocator> Iterator for ExtractIf<'_, T, N, F, A>
 where
     F: FnMut(&mut T) -> bool,
 {
@@ -892,7 +895,7 @@ where
     }
 }
 
-impl<T, F, const N: usize> Drop for ExtractIf<'_, T, N, F>
+impl<T, F, const N: usize, A: Allocator> Drop for ExtractIf<'_, T, N, F, A>
 where
     F: FnMut(&mut T) -> bool,
 {
@@ -916,12 +919,12 @@ where
     }
 }
 
-pub struct Splice<'a, I: Iterator + 'a, const N: usize> {
-    drain: Drain<'a, I::Item, N>,
+pub struct Splice<'a, I: Iterator + 'a, const N: usize, A: Allocator = Global> {
+    drain: Drain<'a, I::Item, N, A>,
     replace_with: I,
 }
 
-impl<'a, I, const N: usize> core::fmt::Debug for Splice<'a, I, N>
+impl<'a, I, const N: usize, A: Allocator> core::fmt::Debug for Splice<'a, I, N, A>
 where
     I: Debug + Iterator + 'a,
     <I as Iterator>::Item: Debug,
@@ -931,7 +934,7 @@ where
     }
 }
 
-impl<I: Iterator, const N: usize> Iterator for Splice<'_, I, N> {
+impl<I: Iterator, const N: usize, A: Allocator> Iterator for Splice<'_, I, N, A> {
     type Item = I::Item;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -943,15 +946,15 @@ impl<I: Iterator, const N: usize> Iterator for Splice<'_, I, N> {
     }
 }
 
-impl<I: Iterator, const N: usize> DoubleEndedIterator for Splice<'_, I, N> {
+impl<I: Iterator, const N: usize, A: Allocator> DoubleEndedIterator for Splice<'_, I, N, A> {
     fn next_back(&mut self) -> Option<Self::Item> {
         self.drain.next_back()
     }
 }
 
-impl<I: Iterator, const N: usize> ExactSizeIterator for Splice<'_, I, N> {}
+impl<I: Iterator, const N: usize, A: Allocator> ExactSizeIterator for Splice<'_, I, N, A> {}
 
-impl<I: Iterator, const N: usize> Drop for Splice<'_, I, N> {
+impl<I: Iterator, const N: usize, A: Allocator> Drop for Splice<'_, I, N, A> {
     fn drop(&mut self) {
         self.drain.by_ref().for_each(drop);
         // At this point draining is done and the only remaining tasks are splicing
@@ -1006,13 +1009,13 @@ impl<I: Iterator, const N: usize> Drop for Splice<'_, I, N> {
 /// Returned from [`SmallVec::into_iter`][1].
 ///
 /// [1]: struct.SmallVec.html#method.into_iter
-pub struct IntoIter<T, const N: usize> {
+pub struct IntoIter<T, const N: usize, A: Allocator = Global> {
     // # Safety
     //
     // `end` decides whether the data lives on the heap or not
     //
     // The members from begin..end are initialized
-    raw: RawSmallVec<T, N>,
+    raw: RawSmallVec<T, N, A>,
     begin: usize,
     end: TaggedLen<T>,
     _marker: PhantomData<T>,
@@ -1020,10 +1023,10 @@ pub struct IntoIter<T, const N: usize> {
 
 // SAFETY: IntoIter has unique ownership of its contents.  Sending (or sharing)
 // an `IntoIter<T, N>` is equivalent to sending (or sharing) a `SmallVec<T, N>`.
-unsafe impl<T, const N: usize> Send for IntoIter<T, N> where T: Send {}
-unsafe impl<T, const N: usize> Sync for IntoIter<T, N> where T: Sync {}
+unsafe impl<T, const N: usize, A: Allocator + Send> Send for IntoIter<T, N, A> where T: Send {}
+unsafe impl<T, const N: usize, A: Allocator + Sync> Sync for IntoIter<T, N, A> where T: Sync {}
 
-impl<T, const N: usize> IntoIter<T, N> {
+impl<T, const N: usize, A: Allocator> IntoIter<T, N, A> {
     #[inline]
     const fn as_ptr(&self) -> *const T {
         let on_heap = self.end.on_heap();
@@ -1066,7 +1069,7 @@ impl<T, const N: usize> IntoIter<T, N> {
     }
 }
 
-impl<T, const N: usize> Iterator for IntoIter<T, N> {
+impl<T, const N: usize, A: Allocator> Iterator for IntoIter<T, N, A> {
     type Item = T;
 
     #[inline]
@@ -1110,8 +1113,8 @@ impl<T, const N: usize> DoubleEndedIterator for IntoIter<T, N> {
         }
     }
 }
-impl<T, const N: usize> ExactSizeIterator for IntoIter<T, N> {}
-impl<T, const N: usize> core::iter::FusedIterator for IntoIter<T, N> {}
+impl<T, const N: usize, A: Allocator> ExactSizeIterator for IntoIter<T, N, A> {}
+impl<T, const N: usize, A: Allocator> core::iter::FusedIterator for IntoIter<T, N, A> {}
 
 impl<T, const N: usize> SmallVec<T, N> {
     #[inline]
@@ -1133,59 +1136,101 @@ impl<T, const N: usize> SmallVec<T, N> {
         }
     }
 
+    /// Creates a `SmallVec` directly from the raw components of another
+    /// `SmallVec`.
+    ///
+    /// # Safety
+    ///
+    /// This is highly unsafe, due to the number of invariants that aren’t
+    /// checked:
+    ///
+    /// - `ptr` needs to have been previously allocated via `SmallVec` from its
+    ///   spilled storage (at least, it’s highly likely to be incorrect if it
+    ///   wasn’t).
+    /// - `ptr`’s `A::Item` type needs to be the same size and alignment that it
+    ///   was allocated with
+    /// - `length` needs to be less than or equal to `capacity`.
+    /// - `capacity` needs to be the capacity that the pointer was allocated
+    ///   with.
+    ///
+    /// Violating these may cause problems like corrupting the allocator’s
+    /// internal data structures.
+    ///
+    /// Additionally, `capacity` must be greater than the amount of inline
+    /// storage `A` has; that is, the new `SmallVec` must need to spill over
+    /// into heap allocated storage. This condition is asserted against.
+    ///
+    /// The ownership of `ptr` is effectively transferred to the `SmallVec`
+    /// which may then deallocate, reallocate or change the contents of memory
+    /// pointed to by the pointer at will. Ensure that nothing else uses the
+    /// pointer after calling this function.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use smallvec::{smallvec, SmallVec};
+    ///
+    /// let mut v: SmallVec<_, 1> = smallvec![1, 2, 3];
+    ///
+    /// // Pull out the important parts of `v`.
+    /// let p = v.as_mut_ptr();
+    /// let len = v.len();
+    /// let cap = v.capacity();
+    /// let spilled = v.spilled();
+    ///
+    /// unsafe {
+    ///     // Forget all about `v`. The heap allocation that stored the
+    ///     // three values won't be deallocated.
+    ///     std::mem::forget(v);
+    ///
+    ///     // Overwrite memory with [4, 5, 6].
+    ///     //
+    ///     // This is only safe if `spilled` is true! Otherwise, we are
+    ///     // writing into the old `SmallVec`'s inline storage on the
+    ///     // stack.
+    ///     assert!(spilled);
+    ///     for i in 0..len {
+    ///         std::ptr::write(p.add(i), 4 + i);
+    ///     }
+    ///
+    ///     // Put everything back together into a SmallVec with a different
+    ///     // amount of inline storage, but which is still less than `cap`.
+    ///     let rebuilt = SmallVec::<_, 2>::from_raw_parts(p, len, cap);
+    ///     assert_eq!(&*rebuilt, &[4, 5, 6]);
+    /// }
+    /// ```
     #[inline]
-    pub const fn from_buf<const S: usize>(elements: [T; S]) -> Self {
-        const {
-            assert!(S <= N);
-        }
+    pub unsafe fn from_raw_parts(ptr: *mut T, length: usize, capacity: usize) -> Self {
+        assert!(!Self::IS_ZST);
 
-        // Although we create a new buffer, since S and N are known at compile time,
-        // even with `-C opt-level=1`, it gets optimized as best as it could be.
-        // (Checked with <godbolt.org>)
-        let mut buf: MaybeUninit<[T; N]> = MaybeUninit::uninit();
+        // SAFETY: We require caller to provide same ptr as we alloc
+        // and we never alloc null pointer.
+        let ptr = unsafe {
+            debug_assert!(!ptr.is_null(), "Called `from_raw_parts` with null pointer.");
+            NonNull::new_unchecked(ptr)
+        };
 
-        // SAFETY: buf and elements do not overlap, are aligned and have space
-        // for at least S elements since S <= N.
-        // We will drop the elements only once since we do forget(elements).
-        unsafe {
-            copy_nonoverlapping(elements.as_ptr(), buf.as_mut_ptr() as *mut T, S);
-        }
-
-        // `elements` have been moved into buf and will be dropped by SmallVec
-        core::mem::forget(elements);
-
-        // SAFETY: all the members in 0..S are initialized
-        Self {
-            len: TaggedLen::new(S, false),
-            raw: RawSmallVec::new_inline(buf),
+        SmallVec {
+            len: TaggedLen::new(length, true),
+            raw: RawSmallVec::new_heap(ptr, capacity),
             _marker: PhantomData,
         }
     }
 
     #[inline]
+    pub fn into_raw_parts(self) -> (*mut T, usize, usize) {
+        let mut me = ManuallyDrop::new(self);
+        (me.as_mut_ptr(), me.len(), me.capacity())
+    }
+
+    #[inline]
+    pub const fn from_buf<const S: usize>(elements: [T; S]) -> Self {
+        Self::from_buf_in::<S>(elements, Global)
+    }
+
+    #[inline]
     pub fn from_buf_and_len(buf: [T; N], len: usize) -> Self {
-        assert!(len <= N);
-        // SAFETY: all the members in 0..len are initialized
-        let mut vec = Self {
-            len: TaggedLen::new(len, false),
-            raw: RawSmallVec::new_inline(MaybeUninit::new(buf)),
-            _marker: PhantomData,
-        };
-        // Deallocate the remaining elements so no memory is leaked.
-        unsafe {
-            // SAFETY: both the input and output pointers are in range of the stack
-            // allocation
-            let remainder_ptr = vec.raw.as_mut_ptr_inline().add(len);
-            let remainder_len = N - len;
-
-            // SAFETY: the values are initialized, so dropping them here is fine.
-            core::ptr::drop_in_place(core::ptr::slice_from_raw_parts_mut(
-                remainder_ptr,
-                remainder_len,
-            ));
-        }
-
-        vec
+        Self::from_buf_and_len_in(buf, len, Global)
     }
 
     /// Constructs a new `SmallVec` on the stack from an A without copying
@@ -1218,38 +1263,250 @@ impl<T, const N: usize> SmallVec<T, N> {
     }
 }
 
-impl<T, const N: usize> SmallVec<T, N> {
+impl<T, const N: usize, A: Allocator> SmallVec<T, N, A> {
     const IS_ZST: bool = is_zst::<T>();
 
     #[inline]
-    pub fn from_vec(vec: Vec<T>) -> Self {
-        if vec.capacity() == 0 {
-            return Self::new();
+    pub const fn new_in(alloc: A) -> Self {
+        Self {
+            len: TaggedLen::new(0, false),
+            raw: RawSmallVec::new_in(alloc),
+            _marker: PhantomData,
+        }
+    }
+
+    #[inline]
+    pub fn with_capacity_in(capacity: usize, alloc: A) -> Self {
+        let on_heap = capacity > const { inline_size::<T, N>() };
+        Self {
+            len: TaggedLen::new(0, on_heap),
+            raw: RawSmallVec::with_capacity_in(capacity, alloc),
+            _marker: PhantomData,
+        }
+    }
+
+    #[inline]
+    pub unsafe fn from_raw_parts_in(ptr: *mut T, length: usize, capacity: usize, alloc: A) -> Self {
+        assert!(!Self::IS_ZST);
+
+        // SAFETY: We require caller to provide same ptr as we alloc
+        // and we never alloc null pointer.
+        let ptr = unsafe {
+            debug_assert!(!ptr.is_null(), "Called `from_raw_parts` with null pointer.");
+            NonNull::new_unchecked(ptr)
+        };
+
+        SmallVec {
+            len: TaggedLen::new(length, true),
+            raw: RawSmallVec::new_heap_in(ptr, capacity, alloc),
+            _marker: PhantomData,
+        }
+    }
+
+    #[inline]
+    pub fn into_raw_parts_with_alloc(self) -> (*mut T, usize, usize, A) {
+        let mut me = ManuallyDrop::new(self);
+        let alloc = unsafe { core::ptr::read(me.allocator()) };
+        (me.as_mut_ptr(), me.len(), me.capacity(), alloc)
+    }
+
+    #[inline]
+    pub const fn from_buf_in<const S: usize>(elements: [T; S], alloc: A) -> Self {
+        const {
+            assert!(S <= N);
         }
 
+        // Although we create a new buffer, since S and N are known at compile time,
+        // even with `-C opt-level=1`, it gets optimized as best as it could be.
+        // (Checked with <godbolt.org>)
+        let mut buf: MaybeUninit<[T; N]> = MaybeUninit::uninit();
+
+        // SAFETY: buf and elements do not overlap, are aligned and have space
+        // for at least S elements since S <= N.
+        // We will drop the elements only once since we do forget(elements).
+        unsafe {
+            copy_nonoverlapping(elements.as_ptr(), buf.as_mut_ptr() as *mut T, S);
+        }
+
+        // `elements` have been moved into buf and will be dropped by SmallVec
+        core::mem::forget(elements);
+
+        // SAFETY: all the members in 0..S are initialized
+        Self {
+            len: TaggedLen::new(S, false),
+            raw: RawSmallVec::new_inline_in(buf, alloc),
+            _marker: PhantomData,
+        }
+    }
+
+    #[inline]
+    pub fn from_buf_and_len_in(buf: [T; N], len: usize, alloc: A) -> Self {
+        assert!(len <= N);
+        // SAFETY: all the members in 0..len are initialized
+        let mut vec = Self {
+            len: TaggedLen::new(len, false),
+            raw: RawSmallVec::new_inline_in(MaybeUninit::new(buf), alloc),
+            _marker: PhantomData,
+        };
+        // Deallocate the remaining elements so no memory is leaked.
+        unsafe {
+            // SAFETY: both the input and output pointers are in range of the stack
+            // allocation
+            let remainder_ptr = vec.raw.as_mut_ptr_inline().add(len);
+            let remainder_len = N - len;
+
+            // SAFETY: the values are initialized, so dropping them here is fine.
+            core::ptr::drop_in_place(core::ptr::slice_from_raw_parts_mut(
+                remainder_ptr,
+                remainder_len,
+            ));
+        }
+
+        vec
+    }
+
+    #[inline]
+    pub const unsafe fn from_buf_and_len_in_unchecked(
+        buf: MaybeUninit<[T; N]>,
+        len: usize,
+        alloc: A,
+    ) -> Self {
+        debug_assert!(len <= N);
+        Self {
+            len: TaggedLen::new(len, false),
+            raw: RawSmallVec::new_inline_in(buf, alloc),
+            _marker: PhantomData,
+        }
+    }
+}
+
+macro_rules! make_heap_methods {
+    (
+        $from_vec:ident,
+        $into_vec:ident,
+        $into_boxed_slice:ident,
+        $vec:path,
+        $box:path $(,)?
+    ) => {
+        impl<T, const N: usize, A: Allocator> SmallVec<T, N, A> {
+            #[inline]
+            pub fn $from_vec(mut vec: $vec) -> Self {
+                if Self::IS_ZST {
+                    let len = vec.len();
+
+                    // We don't wrap the vector in ManuallyDrop so that when it's dropped, the
+                    // memory is deallocated, if it needs to be.
+                    // SAFETY: `0` is less than or equal to the vector's capacity.
+                    // old_len..new_len is an empty range. So there are no uninitialized elements
+                    unsafe { vec.set_len(0) };
+                    vec.shrink_to_fit();
+
+                    let (_ptr, _len, _cap, alloc) = vec.into_raw_parts_with_alloc();
+
+                    Self {
+                        len: TaggedLen::new(len, false),
+                        raw: RawSmallVec::new_in(alloc),
+                        _marker: PhantomData,
+                    }
+                } else {
+                    // FIXME: Use `into_parts_with_alloc` once it is stable.
+                    let (ptr, len, cap, alloc) = vec.into_raw_parts_with_alloc();
+                    // SAFETY: The pointer of a `Vec` is never null.
+                    let ptr = unsafe { NonNull::new_unchecked(ptr) };
+
+                    Self {
+                        len: TaggedLen::new(len, true),
+                        raw: RawSmallVec::new_heap_in(ptr, cap, alloc),
+                        _marker: PhantomData,
+                    }
+                }
+            }
+
+            #[inline]
+            pub fn $into_vec(self) -> $vec {
+                let len = self.len();
+                let this = ManuallyDrop::new(self);
+
+                // SAFETY: The pointer is created using a normal reference
+                // so the pointer must be valid.
+                let alloc = unsafe { core::ptr::read(this.allocator()) };
+
+                if !this.spilled() {
+                    let mut vec = <$vec>::with_capacity_in(len, alloc);
+                    // SAFETY: we create a new vector with sufficient capacity, copy our elements
+                    // into it to transfer ownership and then set the length
+                    // we don't drop the elements we previously held
+                    unsafe {
+                        copy_nonoverlapping(this.raw.as_ptr_inline(), vec.as_mut_ptr(), len);
+                        vec.set_len(len);
+                    }
+                    vec
+                } else {
+                    // SAFETY:
+                    // - `ptr` was created with the global allocator
+                    // - `ptr` was created with the appropriate alignment for `T`
+                    // - the allocation pointed to by ptr is exactly cap * sizeof(T)
+                    // - `len` is less than or equal to `cap`
+                    // - the first `len` entries are proper `T`-values
+                    // - the allocation is not larger than `isize::MAX`
+                    unsafe {
+                        let (ptr, cap) = this.raw.inner.heap;
+                        <$vec>::from_raw_parts_in(ptr.as_ptr(), len, cap, alloc)
+                    }
+                }
+            }
+
+            #[inline]
+            pub fn $into_boxed_slice(self) -> $box {
+                self.$into_vec().into_boxed_slice()
+            }
+        }
+    };
+}
+
+#[cfg(not(feature = "allocator-api2"))]
+make_heap_methods! {
+    from_vec,
+    into_vec,
+    into_boxed_slice,
+    Vec<T, A>,
+    Box<[T], A>,
+}
+
+#[cfg(feature = "allocator-api2")]
+make_heap_methods! {
+    from_vec2,
+    into_vec2,
+    into_boxed_slice2,
+    allocator_api2::vec::Vec<T, A>,
+    allocator_api2::boxed::Box<[T], A>,
+}
+
+/// Functions for interacting with `std` types whenever
+/// the "allocator-api2" feature is enabled.
+#[cfg(feature = "allocator-api2")]
+impl<T, const N: usize> SmallVec<T, N> {
+    #[inline]
+    pub fn from_vec(mut vec: Vec<T>) -> Self {
         if Self::IS_ZST {
-            // "Move" elements to stack buffer. They're ZST so we don't actually have to do
-            // anything. Just make sure they're not dropped.
-            // We don't wrap the vector in ManuallyDrop so that when it's dropped, the
-            // memory is deallocated, if it needs to be.
-            let mut vec = vec;
             let len = vec.len();
 
-            // SAFETY: `0` is less than the vector's capacity.
+            // We don't wrap the vector in ManuallyDrop so that when it's dropped, the
+            // memory is deallocated, if it needs to be.
+            // SAFETY: `0` is less than or equal to the vector's capacity.
             // old_len..new_len is an empty range. So there are no uninitialized elements
             unsafe { vec.set_len(0) };
+
             Self {
                 len: TaggedLen::new(len, false),
                 raw: RawSmallVec::new(),
                 _marker: PhantomData,
             }
         } else {
-            let mut vec = ManuallyDrop::new(vec);
-            let len = vec.len();
-            let cap = vec.capacity();
-            // SAFETY: vec.capacity is not `0` (checked above), so the pointer
-            // can not dangle and thus specifically cannot be null.
-            let ptr = unsafe { NonNull::new_unchecked(vec.as_mut_ptr()) };
+            // FIXME: Use `into_parts` once it is stable.
+            let (ptr, len, cap) = vec.into_raw_parts();
+            // SAFETY: The pointer of a `Vec` is never null.
+            let ptr = unsafe { NonNull::new_unchecked(ptr) };
 
             Self {
                 len: TaggedLen::new(len, true),
@@ -1257,6 +1514,49 @@ impl<T, const N: usize> SmallVec<T, N> {
                 _marker: PhantomData,
             }
         }
+    }
+
+    #[inline]
+    pub fn into_vec(self) -> Vec<T> {
+        let len = self.len();
+        let this = ManuallyDrop::new(self);
+
+        if !this.spilled() {
+            let mut vec = Vec::with_capacity(len);
+            // SAFETY: we create a new vector with sufficient capacity, copy our elements
+            // into it to transfer ownership and then set the length
+            // we don't drop the elements we previously held
+            unsafe {
+                copy_nonoverlapping(this.raw.as_ptr_inline(), vec.as_mut_ptr(), len);
+                vec.set_len(len);
+            }
+            vec
+        } else {
+            // SAFETY:
+            // - `ptr` was created with the global allocator
+            // - `ptr` was created with the appropriate alignment for `T`
+            // - the allocation pointed to by ptr is exactly cap * sizeof(T)
+            // - `len` is less than or equal to `cap`
+            // - the first `len` entries are proper `T`-values
+            // - the allocation is not larger than `isize::MAX`
+            unsafe {
+                let (ptr, cap) = this.raw.inner.heap;
+                Vec::from_raw_parts(ptr.as_ptr(), len, cap)
+            }
+        }
+    }
+
+    #[inline]
+    pub fn into_boxed_slice(self) -> Box<[T]> {
+        self.into_vec().into_boxed_slice()
+    }
+}
+
+impl<T, const N: usize, A: Allocator> SmallVec<T, N, A> {
+    /// Returns a reference to the underlying allocator.
+    #[inline]
+    pub fn allocator(&self) -> &A {
+        &self.raw.allocator
     }
 
     /// Sets the tag to be on the heap
@@ -1298,11 +1598,7 @@ impl<T, const N: usize> SmallVec<T, N> {
 
     #[inline]
     pub const fn inline_size() -> usize {
-        if Self::IS_ZST {
-            usize::MAX
-        } else {
-            N
-        }
+        const { inline_size::<T, N>() }
     }
 
     #[inline]
@@ -1358,12 +1654,15 @@ impl<T, const N: usize> SmallVec<T, N> {
     /// assert_eq!(vec2, [2, 3]);
     /// ```
     #[inline]
-    pub fn split_off(&mut self, at: usize) -> Self {
+    pub fn split_off(&mut self, at: usize) -> Self
+    where
+        A: Clone,
+    {
         let len = self.len();
         assert!(at <= len);
 
         let other_len = len - at;
-        let mut other = Self::with_capacity(other_len);
+        let mut other = Self::with_capacity_in(other_len, self.allocator().clone());
 
         // Unsafely `set_len` and copy items to `other`.
         unsafe {
@@ -1375,7 +1674,7 @@ impl<T, const N: usize> SmallVec<T, N> {
         other
     }
 
-    pub fn drain<R>(&mut self, range: R) -> Drain<'_, T, N>
+    pub fn drain<R>(&mut self, range: R) -> Drain<'_, T, N, A>
     where
         R: core::ops::RangeBounds<usize>,
     {
@@ -1486,7 +1785,7 @@ impl<T, const N: usize> SmallVec<T, N> {
     /// );
     /// assert_eq!(ones.len(), 3);
     /// ```
-    pub fn extract_if<F, R>(&mut self, range: R, filter: F) -> ExtractIf<'_, T, N, F>
+    pub fn extract_if<F, R>(&mut self, range: R, filter: F) -> ExtractIf<'_, T, N, F, A>
     where
         F: FnMut(&mut T) -> bool,
         R: core::ops::RangeBounds<usize>,
@@ -1509,7 +1808,7 @@ impl<T, const N: usize> SmallVec<T, N> {
         }
     }
 
-    pub fn splice<R, I>(&mut self, range: R, replace_with: I) -> Splice<'_, I::IntoIter, N>
+    pub fn splice<R, I>(&mut self, range: R, replace_with: I) -> Splice<'_, I::IntoIter, N, A>
     where
         R: core::ops::RangeBounds<usize>,
         I: IntoIterator<Item = T>,
@@ -1583,7 +1882,7 @@ impl<T, const N: usize> SmallVec<T, N> {
     }
 
     #[inline]
-    pub fn append<const M: usize>(&mut self, other: &mut SmallVec<T, M>) {
+    pub fn append<const M: usize, A2: Allocator>(&mut self, other: &mut SmallVec<T, M, A2>) {
         // can't overflow since both are smaller than isize::MAX and 2 * isize::MAX <
         // usize::MAX
         let len = self.len();
@@ -1840,41 +2139,6 @@ impl<T, const N: usize> SmallVec<T, N> {
     }
 
     #[inline]
-    pub fn into_vec(self) -> Vec<T> {
-        let len = self.len();
-        if !self.spilled() {
-            let mut vec = Vec::with_capacity(len);
-            let this = ManuallyDrop::new(self);
-            // SAFETY: we create a new vector with sufficient capacity, copy our elements
-            // into it to transfer ownership and then set the length
-            // we don't drop the elements we previously held
-            unsafe {
-                copy_nonoverlapping(this.raw.as_ptr_inline(), vec.as_mut_ptr(), len);
-                vec.set_len(len);
-            }
-            vec
-        } else {
-            let this = ManuallyDrop::new(self);
-            // SAFETY:
-            // - `ptr` was created with the global allocator
-            // - `ptr` was created with the appropriate alignment for `T`
-            // - the allocation pointed to by ptr is exactly cap * sizeof(T)
-            // - `len` is less than or equal to `cap`
-            // - the first `len` entries are proper `T`-values
-            // - the allocation is not larger than `isize::MAX`
-            unsafe {
-                let (ptr, cap) = this.raw.inner.heap;
-                Vec::from_raw_parts(ptr.as_ptr(), len, cap)
-            }
-        }
-    }
-
-    #[inline]
-    pub fn into_boxed_slice(self) -> Box<[T]> {
-        self.into_vec().into_boxed_slice()
-    }
-
-    #[inline]
     pub fn into_inner(self) -> Result<[T; N], Self> {
         if self.len() != N {
             Err(self)
@@ -2013,90 +2277,40 @@ impl<T, const N: usize> SmallVec<T, N> {
             )
         }
     }
-
-    /// Creates a `SmallVec` directly from the raw components of another
-    /// `SmallVec`.
-    ///
-    /// # Safety
-    ///
-    /// This is highly unsafe, due to the number of invariants that aren’t
-    /// checked:
-    ///
-    /// - `ptr` needs to have been previously allocated via `SmallVec` from its
-    ///   spilled storage (at least, it’s highly likely to be incorrect if it
-    ///   wasn’t).
-    /// - `ptr`’s `A::Item` type needs to be the same size and alignment that it
-    ///   was allocated with
-    /// - `length` needs to be less than or equal to `capacity`.
-    /// - `capacity` needs to be the capacity that the pointer was allocated
-    ///   with.
-    ///
-    /// Violating these may cause problems like corrupting the allocator’s
-    /// internal data structures.
-    ///
-    /// Additionally, `capacity` must be greater than the amount of inline
-    /// storage `A` has; that is, the new `SmallVec` must need to spill over
-    /// into heap allocated storage. This condition is asserted against.
-    ///
-    /// The ownership of `ptr` is effectively transferred to the `SmallVec`
-    /// which may then deallocate, reallocate or change the contents of memory
-    /// pointed to by the pointer at will. Ensure that nothing else uses the
-    /// pointer after calling this function.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use smallvec::{smallvec, SmallVec};
-    ///
-    /// let mut v: SmallVec<_, 1> = smallvec![1, 2, 3];
-    ///
-    /// // Pull out the important parts of `v`.
-    /// let p = v.as_mut_ptr();
-    /// let len = v.len();
-    /// let cap = v.capacity();
-    /// let spilled = v.spilled();
-    ///
-    /// unsafe {
-    ///     // Forget all about `v`. The heap allocation that stored the
-    ///     // three values won't be deallocated.
-    ///     std::mem::forget(v);
-    ///
-    ///     // Overwrite memory with [4, 5, 6].
-    ///     //
-    ///     // This is only safe if `spilled` is true! Otherwise, we are
-    ///     // writing into the old `SmallVec`'s inline storage on the
-    ///     // stack.
-    ///     assert!(spilled);
-    ///     for i in 0..len {
-    ///         std::ptr::write(p.add(i), 4 + i);
-    ///     }
-    ///
-    ///     // Put everything back together into a SmallVec with a different
-    ///     // amount of inline storage, but which is still less than `cap`.
-    ///     let rebuilt = SmallVec::<_, 2>::from_raw_parts(p, len, cap);
-    ///     assert_eq!(&*rebuilt, &[4, 5, 6]);
-    /// }
-    /// ```
-    #[inline]
-    pub unsafe fn from_raw_parts(ptr: *mut T, length: usize, capacity: usize) -> SmallVec<T, N> {
-        assert!(!Self::IS_ZST);
-
-        // SAFETY: We require caller to provide same ptr as we alloc
-        // and we never alloc null pointer.
-        let ptr = unsafe {
-            debug_assert!(!ptr.is_null(), "Called `from_raw_parts` with null pointer.");
-            NonNull::new_unchecked(ptr)
-        };
-
-        SmallVec {
-            len: TaggedLen::new(length, true),
-            raw: RawSmallVec::new_heap(ptr, capacity),
-            _marker: PhantomData,
-        }
-    }
 }
 
-impl<T: Clone, const N: usize> SmallVec<T, N> {
+impl<T: Clone, const N: usize, A: Allocator + Clone> SmallVec<T, N, A> {
+    /// Creates a [`SmallVec`] value from the slice `slice` with the specified
+    /// allocator.
+    pub fn from_slice_in(slice: &[T], alloc: A) -> Self {
+        if slice.len() > const { Self::inline_size() } {
+            #[cfg(feature = "allocator-api2")]
+            {
+                // Standard Rust vectors are already specialized.
+                Self::from_vec2(slice.to_vec_in2(alloc))
+            }
+
+            #[cfg(not(feature = "allocator-api2"))]
+            {
+                // Standard Rust vectors are already specialized.
+                Self::from_vec(slice.to_vec_in(alloc))
+            }
+        } else {
+            // SAFETY: The precondition is checked in the initial comparison above.
+            unsafe {
+                #[cfg(feature = "specialization")]
+                {
+                    <Self as spec_traits::SpecFromSlice<T, A>>::spec_from(slice, alloc)
+                }
+
+                #[cfg(not(feature = "specialization"))]
+                {
+                    Self::from_slice_fallback(slice, alloc)
+                }
+            }
+        }
+    }
+
     #[inline]
     pub fn resize(&mut self, len: usize, value: T) {
         let old_len = self.len();
@@ -2195,16 +2409,30 @@ impl<T: Clone, const N: usize> SmallVec<T, N> {
             self.set_len(l + len);
         }
     }
+}
 
+impl<T, const N: usize> SmallVec<T, N> {
     /// A function for creating [`SmallVec`] values out of slices
     /// for types with the [`Copy`] trait.
+    #[inline]
     pub fn from_slice_copy(slice: &[T]) -> Self
+    where
+        T: Copy,
+    {
+        Self::from_slice_copy_in(slice, Global)
+    }
+}
+
+impl<T, const N: usize, A: Allocator> SmallVec<T, N, A> {
+    /// A function for creating [`SmallVec`] values out of slices
+    /// for types with the [`Copy`] trait. Supports custom allocators.
+    pub fn from_slice_copy_in(slice: &[T], alloc: A) -> Self
     where
         T: Copy,
     {
         let src = slice.as_ptr();
         let len = slice.len();
-        let mut result = Self::with_capacity(len);
+        let mut result = Self::with_capacity_in(len, alloc);
 
         // SAFETY: By using `with_capacity`, the pointer will point to valid memory.
         unsafe {
@@ -2251,7 +2479,7 @@ impl Drop for DropDealloc {
 }
 
 #[cfg(feature = "may_dangle")]
-unsafe impl<#[may_dangle] T, const N: usize> Drop for SmallVec<T, N> {
+unsafe impl<#[may_dangle] T, const N: usize, A: Allocator> Drop for SmallVec<T, N, A> {
     fn drop(&mut self) {
         let on_heap = self.spilled();
         let len = self.len();
@@ -2275,7 +2503,7 @@ unsafe impl<#[may_dangle] T, const N: usize> Drop for SmallVec<T, N> {
 }
 
 #[cfg(not(feature = "may_dangle"))]
-impl<T, const N: usize> Drop for SmallVec<T, N> {
+impl<T, const N: usize, A: Allocator> Drop for SmallVec<T, N, A> {
     fn drop(&mut self) {
         let on_heap = self.spilled();
         let len = self.len();
@@ -2297,7 +2525,7 @@ impl<T, const N: usize> Drop for SmallVec<T, N> {
     }
 }
 
-impl<T, const N: usize> Drop for IntoIter<T, N> {
+impl<T, const N: usize, A: Allocator> Drop for IntoIter<T, N, A> {
     fn drop(&mut self) {
         // SAFETY: see above
         unsafe {
@@ -2320,7 +2548,7 @@ impl<T, const N: usize> Drop for IntoIter<T, N> {
     }
 }
 
-impl<T, const N: usize> core::ops::Deref for SmallVec<T, N> {
+impl<T, const N: usize, A: Allocator> core::ops::Deref for SmallVec<T, N, A> {
     type Target = [T];
 
     #[inline]
@@ -2328,7 +2556,7 @@ impl<T, const N: usize> core::ops::Deref for SmallVec<T, N> {
         self.as_slice()
     }
 }
-impl<T, const N: usize> core::ops::DerefMut for SmallVec<T, N> {
+impl<T, const N: usize, A: Allocator> core::ops::DerefMut for SmallVec<T, N, A> {
     #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.as_mut_slice()
@@ -2336,7 +2564,7 @@ impl<T, const N: usize> core::ops::DerefMut for SmallVec<T, N> {
 }
 
 /// This function is used in the [`smallvec`] macro.
-/// It is recommended to use the macro instead of using thís function.
+/// It is recommended to use the macro instead of using this function.
 #[doc(hidden)]
 #[track_caller]
 pub fn from_elem<T: Clone, const N: usize>(elem: T, n: usize) -> SmallVec<T, N> {
@@ -2347,13 +2575,54 @@ pub fn from_elem<T: Clone, const N: usize>(elem: T, n: usize) -> SmallVec<T, N> 
         #[cfg(feature = "specialization")]
         {
             // SAFETY: The precondition is checked in the initial comparison above.
-            unsafe { <SmallVec<T, N> as spec_traits::SpecFromElem<T>>::spec_from_elem(elem, n) }
+            unsafe {
+                <SmallVec<T, N, Global> as spec_traits::SpecFromElem<T, Global>>::spec_from_elem(
+                    elem, n, Global,
+                )
+            }
         }
 
         #[cfg(not(feature = "specialization"))]
         {
             // SAFETY: The precondition is checked in the initial comparison above.
-            unsafe { SmallVec::<T, N>::from_elem_fallback(elem, n) }
+            unsafe { SmallVec::<T, N, Global>::from_elem_fallback(elem, n, Global) }
+        }
+    }
+}
+
+#[doc(hidden)]
+#[track_caller]
+pub fn from_elem_in<T: Clone, const N: usize, A: Allocator>(
+    elem: T,
+    n: usize,
+    alloc: A,
+) -> SmallVec<T, N, A> {
+    if n > SmallVec::<T, N, A>::inline_size() {
+        #[cfg(feature = "allocator-api2")]
+        {
+            SmallVec::<T, N, A>::from_vec2(allocator_api2::vec::from_elem_in(elem, n, alloc))
+        }
+
+        #[cfg(not(feature = "allocator-api2"))]
+        {
+            // Standard Rust vectors are already specialized.
+            SmallVec::<T, N, A>::from_vec(alloc::vec::from_elem_in(elem, n, alloc))
+        }
+    } else {
+        #[cfg(feature = "specialization")]
+        {
+            // SAFETY: The precondition is checked in the initial comparison above.
+            unsafe {
+                <SmallVec<T, N, A> as spec_traits::SpecFromElem<T, A>>::spec_from_elem(
+                    elem, n, alloc,
+                )
+            }
+        }
+
+        #[cfg(not(feature = "specialization"))]
+        {
+            // SAFETY: The precondition is checked in the initial comparison above.
+            unsafe { SmallVec::<T, N, A>::from_elem_fallback(elem, n, alloc) }
         }
     }
 }
@@ -2365,27 +2634,27 @@ mod spec_traits {
     /// A trait for specializing the implementation of [`from_elem`].
     ///
     /// [`from_elem`]: crate::from_elem
-    pub(crate) trait SpecFromElem<T> {
+    pub(crate) trait SpecFromElem<T, A: Allocator> {
         /// Creates a `Smallvec` value where `elem` is repeated `n` times.
         /// This will use the inline storage, not the heap.
         ///
         /// # Safety
         ///
         /// The caller must ensure that `n <= Self::inline_size()`.
-        unsafe fn spec_from_elem(elem: T, n: usize) -> Self;
+        unsafe fn spec_from_elem(elem: T, n: usize, alloc: A) -> Self;
     }
 
-    impl<T: Clone, const N: usize> SpecFromElem<T> for SmallVec<T, N> {
+    impl<T: Clone, const N: usize, A: Allocator> SpecFromElem<T, A> for SmallVec<T, N, A> {
         #[inline]
-        default unsafe fn spec_from_elem(elem: T, n: usize) -> Self {
+        default unsafe fn spec_from_elem(elem: T, n: usize, alloc: A) -> Self {
             // SAFETY: Safety conditions are identical.
-            unsafe { SmallVec::from_elem_fallback(elem, n) }
+            unsafe { SmallVec::from_elem_fallback(elem, n, alloc) }
         }
     }
 
-    impl<T: Copy, const N: usize> SpecFromElem<T> for SmallVec<T, N> {
-        unsafe fn spec_from_elem(elem: T, n: usize) -> Self {
-            let mut result = Self::new();
+    impl<T: Copy, const N: usize, A: Allocator> SpecFromElem<T, A> for SmallVec<T, N, A> {
+        unsafe fn spec_from_elem(elem: T, n: usize, alloc: A) -> Self {
+            let mut result = Self::new_in(alloc);
 
             if n > 0 {
                 let ptr = result.raw.as_mut_ptr_inline();
@@ -2417,7 +2686,7 @@ mod spec_traits {
         fn spec_extend(&mut self, iter: I);
     }
 
-    impl<T, I, const N: usize> SpecExtend<T, I> for SmallVec<T, N>
+    impl<T, I, const N: usize, A: Allocator> SpecExtend<T, I> for SmallVec<T, N, A>
     where
         I: Iterator<Item = T>,
     {
@@ -2427,7 +2696,7 @@ mod spec_traits {
         }
     }
 
-    impl<T, I, const N: usize> SpecExtend<T, I> for SmallVec<T, N>
+    impl<T, I, const N: usize, A: Allocator> SpecExtend<T, I> for SmallVec<T, N, A>
     where
         I: core::iter::TrustedLen<Item = T>,
     {
@@ -2458,7 +2727,9 @@ mod spec_traits {
         }
     }
 
-    impl<T, const N: usize, const M: usize> SpecExtend<T, IntoIter<T, M>> for SmallVec<T, N> {
+    impl<T, const N: usize, const M: usize, A: Allocator> SpecExtend<T, IntoIter<T, M>>
+        for SmallVec<T, N, A>
+    {
         fn spec_extend(&mut self, mut iter: IntoIter<T, M>) {
             let slice = iter.as_slice();
             let len = slice.len();
@@ -2484,7 +2755,7 @@ mod spec_traits {
         }
     }
 
-    impl<'a, T: 'a, const N: usize, I> SpecExtend<&'a T, I> for SmallVec<T, N>
+    impl<'a, T: 'a, const N: usize, I, A: Allocator> SpecExtend<&'a T, I> for SmallVec<T, N, A>
     where
         I: Iterator<Item = &'a T>,
         T: Clone,
@@ -2495,7 +2766,8 @@ mod spec_traits {
         }
     }
 
-    impl<'a, T: 'a, const N: usize> SpecExtend<&'a T, core::slice::Iter<'a, T>> for SmallVec<T, N>
+    impl<'a, T: 'a, const N: usize, A: Allocator> SpecExtend<&'a T, core::slice::Iter<'a, T>>
+        for SmallVec<T, N, A>
     where
         T: Copy,
     {
@@ -2537,7 +2809,7 @@ mod spec_traits {
         unsafe fn spec_extend_from_within(&mut self, src: core::ops::Range<usize>);
     }
 
-    impl<T: Clone, const N: usize> SpecExtendFromWithin<T> for SmallVec<T, N> {
+    impl<T: Clone, const N: usize, A: Allocator> SpecExtendFromWithin<T> for SmallVec<T, N, A> {
         default unsafe fn spec_extend_from_within(&mut self, src: core::ops::Range<usize>) {
             // SAFETY: Safety conditions are identical.
             unsafe {
@@ -2546,7 +2818,7 @@ mod spec_traits {
         }
     }
 
-    impl<T: Copy, const N: usize> SpecExtendFromWithin<T> for SmallVec<T, N> {
+    impl<T: Copy, const N: usize, A: Allocator> SpecExtendFromWithin<T> for SmallVec<T, N, A> {
         unsafe fn spec_extend_from_within(&mut self, src: core::ops::Range<usize>) {
             let old_len = self.len();
 
@@ -2571,29 +2843,27 @@ mod spec_traits {
     }
 
     /// A trait for specializing the implementation of [`FromIterator`].
-    ///
-    /// [`clone_from`]: Clone::clone_from
-    pub(crate) trait SpecFromIterator<T, I> {
-        fn spec_from_iter(iter: I) -> Self;
+    pub(crate) trait SpecFromIterator<T, I, A> {
+        fn spec_from_iter(iter: I, alloc: A) -> Self;
     }
 
-    impl<T, I, const N: usize> SpecFromIterator<T, I> for SmallVec<T, N>
+    impl<T, I, const N: usize, A: Allocator> SpecFromIterator<T, I, A> for SmallVec<T, N, A>
     where
         I: Iterator<Item = T>,
     {
         #[inline]
-        default fn spec_from_iter(iter: I) -> Self {
-            Self::from_iter_fallback(iter)
+        default fn spec_from_iter(iter: I, alloc: A) -> Self {
+            Self::from_iter_fallback(iter, alloc)
         }
     }
 
-    impl<T, I, const N: usize> SpecFromIterator<T, I> for SmallVec<T, N>
+    impl<T, I, const N: usize, A: Allocator> SpecFromIterator<T, I, A> for SmallVec<T, N, A>
     where
         I: core::iter::TrustedLen<Item = T>,
     {
-        fn spec_from_iter(iter: I) -> Self {
+        fn spec_from_iter(iter: I, alloc: A) -> Self {
             let mut v = match iter.size_hint() {
-                (_, Some(upper)) => SmallVec::with_capacity(upper),
+                (_, Some(upper)) => SmallVec::with_capacity_in(upper, alloc),
                 // TrustedLen contract guarantees that `size_hint() == (_, None)` means that there
                 // are more than `usize::MAX` elements.
                 // Since the previous branch would eagerly panic if the capacity is too large
@@ -2613,14 +2883,14 @@ mod spec_traits {
         fn spec_clone_from(&mut self, source: &[T]);
     }
 
-    impl<T: Clone, const N: usize> SpecCloneFrom<T> for SmallVec<T, N> {
+    impl<T: Clone, const N: usize, A: Allocator + Clone> SpecCloneFrom<T> for SmallVec<T, N, A> {
         #[inline]
         default fn spec_clone_from(&mut self, source: &[T]) {
             self.clone_from_fallback(source);
         }
     }
 
-    impl<T: Copy, const N: usize> SpecCloneFrom<T> for SmallVec<T, N> {
+    impl<T: Copy, const N: usize, A: Allocator + Clone> SpecCloneFrom<T> for SmallVec<T, N, A> {
         fn spec_clone_from(&mut self, source: &[T]) {
             self.clear();
             self.extend_from_slice(source);
@@ -2629,26 +2899,26 @@ mod spec_traits {
 
     /// A trait for specializing the implementation of [`From`]
     /// with the source type being slices.
-    pub(crate) trait SpecFromSlice<T> {
+    pub(crate) trait SpecFromSlice<T, A> {
         /// Creates a `SmallVec` value based on the contents of `slice`.
         /// This will use the inline storage, not the heap.
         ///
         /// # Safety
         ///
         /// The caller must ensure that `slice.len() <= Self::inline_size()`.
-        unsafe fn spec_from(slice: &[T]) -> Self;
+        unsafe fn spec_from(slice: &[T], alloc: A) -> Self;
     }
 
-    impl<T: Clone, const N: usize> SpecFromSlice<T> for SmallVec<T, N> {
-        default unsafe fn spec_from(slice: &[T]) -> Self {
+    impl<T: Clone, const N: usize, A: Allocator> SpecFromSlice<T, A> for SmallVec<T, N, A> {
+        default unsafe fn spec_from(slice: &[T], alloc: A) -> Self {
             // SAFETY: Safety conditions are identical.
-            unsafe { Self::from_slice_fallback(slice) }
+            unsafe { Self::from_slice_fallback(slice, alloc) }
         }
     }
 
-    impl<T: Copy, const N: usize> SpecFromSlice<T> for SmallVec<T, N> {
-        unsafe fn spec_from(slice: &[T]) -> Self {
-            let mut v = Self::new();
+    impl<T: Copy, const N: usize, A: Allocator> SpecFromSlice<T, A> for SmallVec<T, N, A> {
+        unsafe fn spec_from(slice: &[T], alloc: A) -> Self {
+            let mut v = Self::new_in(alloc);
 
             let src = slice.as_ptr();
             let len = slice.len();
@@ -2673,18 +2943,18 @@ mod spec_traits {
 /// Fallback functions for various specialized methods. These are kept in
 /// a separate implementation block for easy access whenever specialization is
 /// disabled.
-impl<T, const N: usize> SmallVec<T, N> {
+impl<T, const N: usize, A: Allocator> SmallVec<T, N, A> {
     /// Creates a `Smallvec` value where `elem` is repeated `n` times.
     /// This will use the inline storage, not the heap.
     ///
     /// # Safety
     ///
     /// The caller must ensure that `n <= Self::inline_size()`.
-    unsafe fn from_elem_fallback(elem: T, n: usize) -> Self
+    unsafe fn from_elem_fallback(elem: T, n: usize, alloc: A) -> Self
     where
         T: Clone,
     {
-        let mut result = Self::new();
+        let mut result = Self::new_in(alloc);
 
         if n > 0 {
             let ptr = result.raw.as_mut_ptr_inline();
@@ -2764,12 +3034,12 @@ impl<T, const N: usize> SmallVec<T, N> {
         }
     }
 
-    fn from_iter_fallback<I>(iter: I) -> Self
+    fn from_iter_fallback<I>(iter: I, alloc: A) -> Self
     where
         I: Iterator<Item = T>,
     {
         let (size, _) = iter.size_hint();
-        let mut v = Self::with_capacity(size);
+        let mut v = Self::with_capacity_in(size, alloc);
         for x in iter {
             v.push(x);
         }
@@ -2800,11 +3070,11 @@ impl<T, const N: usize> SmallVec<T, N> {
     /// # Safety
     ///
     /// The caller must ensure that `slice.len() <= Self::inline_size()`.
-    unsafe fn from_slice_fallback(slice: &[T]) -> Self
+    unsafe fn from_slice_fallback(slice: &[T], alloc: A) -> Self
     where
         T: Clone,
     {
-        let mut v = Self::new();
+        let mut v = Self::new_in(alloc);
 
         let src = slice.as_ptr();
         let len = slice.len();
@@ -2842,12 +3112,12 @@ impl<T: Clone, const N: usize> From<&[T]> for SmallVec<T, N> {
             unsafe {
                 #[cfg(feature = "specialization")]
                 {
-                    <Self as spec_traits::SpecFromSlice<T>>::spec_from(slice)
+                    <Self as spec_traits::SpecFromSlice<T, Global>>::spec_from(slice, Global)
                 }
 
                 #[cfg(not(feature = "specialization"))]
                 {
-                    Self::from_slice_fallback(slice)
+                    Self::from_slice_fallback(slice, Global)
                 }
             }
         }
@@ -2880,7 +3150,7 @@ impl<T, const N: usize, const M: usize> From<[T; M]> for SmallVec<T, N> {
         if M > N {
             // If M > N, we'd have to heap allocate anyway,
             // so delegate for Vec for the allocation.
-            Self::from(Vec::from(array))
+            Self::from_vec(Vec::from(array))
         } else {
             // M <= N
             let mut this = Self::new();
@@ -2896,16 +3166,33 @@ impl<T, const N: usize, const M: usize> From<[T; M]> for SmallVec<T, N> {
     }
 }
 
+#[cfg(feature = "allocator-api2")]
 impl<T, const N: usize> From<Vec<T>> for SmallVec<T, N> {
     fn from(array: Vec<T>) -> Self {
         Self::from_vec(array)
     }
 }
 
-impl<T: Clone, const N: usize> Clone for SmallVec<T, N> {
+macro_rules! make_from_impl {
+    ($vec:path, $from_vec:ident) => {
+        impl<T, const N: usize, A: Allocator> From<$vec> for SmallVec<T, N, A> {
+            fn from(array: $vec) -> Self {
+                Self::$from_vec(array)
+            }
+        }
+    };
+}
+
+#[cfg(feature = "allocator-api2")]
+make_from_impl!(allocator_api2::vec::Vec<T, A>, from_vec2);
+#[cfg(not(feature = "allocator-api2"))]
+make_from_impl!(Vec<T, A>, from_vec);
+
+impl<T: Clone, const N: usize, A: Allocator + Clone> Clone for SmallVec<T, N, A> {
     #[inline]
-    fn clone(&self) -> SmallVec<T, N> {
-        SmallVec::from(self.as_slice())
+    fn clone(&self) -> SmallVec<T, N, A> {
+        let alloc = self.raw.allocator.clone();
+        Self::from_slice_in(self.as_slice(), alloc)
     }
 
     #[inline]
@@ -2922,14 +3209,15 @@ impl<T: Clone, const N: usize> Clone for SmallVec<T, N> {
     }
 }
 
-impl<T: Clone, const N: usize> Clone for IntoIter<T, N> {
+impl<T: Clone, const N: usize, A: Allocator + Clone> Clone for IntoIter<T, N, A> {
     #[inline]
-    fn clone(&self) -> IntoIter<T, N> {
-        SmallVec::from(self.as_slice()).into_iter()
+    fn clone(&self) -> IntoIter<T, N, A> {
+        let alloc = self.raw.allocator.clone();
+        SmallVec::from_slice_in(self.as_slice(), alloc).into_iter()
     }
 }
 
-impl<T, const N: usize> Extend<T> for SmallVec<T, N> {
+impl<T, const N: usize, A: Allocator> Extend<T> for SmallVec<T, N, A> {
     #[inline]
     fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
         #[cfg(feature = "specialization")]
@@ -2944,7 +3232,7 @@ impl<T, const N: usize> Extend<T> for SmallVec<T, N> {
     }
 }
 
-impl<'a, T: Clone + 'a, const N: usize> Extend<&'a T> for SmallVec<T, N> {
+impl<'a, T: Clone + 'a, const N: usize, A: Allocator> Extend<&'a T> for SmallVec<T, N, A> {
     #[inline]
     fn extend<I: IntoIterator<Item = &'a T>>(&mut self, iter: I) {
         #[cfg(feature = "specialization")]
@@ -2964,12 +3252,12 @@ impl<T, const N: usize> core::iter::FromIterator<T> for SmallVec<T, N> {
     fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
         #[cfg(feature = "specialization")]
         {
-            spec_traits::SpecFromIterator::<T, _>::spec_from_iter(iter.into_iter())
+            spec_traits::SpecFromIterator::<T, _, _>::spec_from_iter(iter.into_iter(), Global)
         }
 
         #[cfg(not(feature = "specialization"))]
         {
-            Self::from_iter_fallback(iter.into_iter())
+            Self::from_iter_fallback(iter.into_iter(), Global)
         }
     }
 }
@@ -2996,8 +3284,8 @@ macro_rules! smallvec_inline {
     });
 }
 
-impl<T, const N: usize> IntoIterator for SmallVec<T, N> {
-    type IntoIter = IntoIter<T, N>;
+impl<T, const N: usize, A: Allocator> IntoIterator for SmallVec<T, N, A> {
+    type IntoIter = IntoIter<T, N, A>;
     type Item = T;
     fn into_iter(self) -> Self::IntoIter {
         // SAFETY: we move out of this.raw by reading the value at its address, which is
@@ -3006,7 +3294,7 @@ impl<T, const N: usize> IntoIterator for SmallVec<T, N> {
             // Set SmallVec len to zero as `IntoIter` drop handles dropping of the elements
             let this = ManuallyDrop::new(self);
             IntoIter {
-                raw: (&this.raw as *const RawSmallVec<T, N>).read(),
+                raw: (&this.raw as *const RawSmallVec<T, N, A>).read(),
                 begin: 0,
                 end: this.len,
                 _marker: PhantomData,
@@ -3015,7 +3303,7 @@ impl<T, const N: usize> IntoIterator for SmallVec<T, N> {
     }
 }
 
-impl<'a, T, const N: usize> IntoIterator for &'a SmallVec<T, N> {
+impl<'a, T, const N: usize, A: Allocator> IntoIterator for &'a SmallVec<T, N, A> {
     type IntoIter = core::slice::Iter<'a, T>;
     type Item = &'a T;
     fn into_iter(self) -> Self::IntoIter {
@@ -3023,7 +3311,7 @@ impl<'a, T, const N: usize> IntoIterator for &'a SmallVec<T, N> {
     }
 }
 
-impl<'a, T, const N: usize> IntoIterator for &'a mut SmallVec<T, N> {
+impl<'a, T, const N: usize, A: Allocator> IntoIterator for &'a mut SmallVec<T, N, A> {
     type IntoIter = core::slice::IterMut<'a, T>;
     type Item = &'a mut T;
     fn into_iter(self) -> Self::IntoIter {
@@ -3031,18 +3319,19 @@ impl<'a, T, const N: usize> IntoIterator for &'a mut SmallVec<T, N> {
     }
 }
 
-impl<T, U, const N: usize, const M: usize> PartialEq<SmallVec<U, M>> for SmallVec<T, N>
+impl<T, U, const N: usize, const M: usize, A1: Allocator, A2: Allocator>
+    PartialEq<SmallVec<U, M, A2>> for SmallVec<T, N, A1>
 where
     T: PartialEq<U>,
 {
     #[inline]
-    fn eq(&self, other: &SmallVec<U, M>) -> bool {
+    fn eq(&self, other: &SmallVec<U, M, A2>) -> bool {
         self.as_slice().eq(other.as_slice())
     }
 }
-impl<T, const N: usize> Eq for SmallVec<T, N> where T: Eq {}
+impl<T, const N: usize, A: Allocator> Eq for SmallVec<T, N, A> where T: Eq {}
 
-impl<T, U, const N: usize, const M: usize> PartialEq<[U; M]> for SmallVec<T, N>
+impl<T, U, const N: usize, const M: usize, A: Allocator> PartialEq<[U; M]> for SmallVec<T, N, A>
 where
     T: PartialEq<U>,
 {
@@ -3062,7 +3351,7 @@ where
     }
 }
 
-impl<T, U, const N: usize> PartialEq<[U]> for SmallVec<T, N>
+impl<T, U, const N: usize, A: Allocator> PartialEq<[U]> for SmallVec<T, N, A>
 where
     T: PartialEq<U>,
 {
@@ -3072,7 +3361,7 @@ where
     }
 }
 
-impl<T, U, const N: usize> PartialEq<&[U]> for SmallVec<T, N>
+impl<T, U, const N: usize, A: Allocator> PartialEq<&[U]> for SmallVec<T, N, A>
 where
     T: PartialEq<U>,
 {
@@ -3082,7 +3371,7 @@ where
     }
 }
 
-impl<T, U, const N: usize> PartialEq<&mut [U]> for SmallVec<T, N>
+impl<T, U, const N: usize, A: Allocator> PartialEq<&mut [U]> for SmallVec<T, N, A>
 where
     T: PartialEq<U>,
 {
@@ -3092,73 +3381,74 @@ where
     }
 }
 
-impl<T, const N: usize> PartialOrd for SmallVec<T, N>
+impl<T, const N1: usize, const M: usize, A1: Allocator, A2: Allocator>
+    PartialOrd<SmallVec<T, M, A2>> for SmallVec<T, N1, A1>
 where
     T: PartialOrd,
 {
     #[inline]
-    fn partial_cmp(&self, other: &SmallVec<T, N>) -> Option<core::cmp::Ordering> {
+    fn partial_cmp(&self, other: &SmallVec<T, M, A2>) -> Option<core::cmp::Ordering> {
         self.as_slice().partial_cmp(other.as_slice())
     }
 }
 
-impl<T, const N: usize> Ord for SmallVec<T, N>
+impl<T, const N: usize, A: Allocator> Ord for SmallVec<T, N, A>
 where
     T: Ord,
 {
     #[inline]
-    fn cmp(&self, other: &SmallVec<T, N>) -> core::cmp::Ordering {
+    fn cmp(&self, other: &SmallVec<T, N, A>) -> core::cmp::Ordering {
         self.as_slice().cmp(other.as_slice())
     }
 }
 
-impl<T: Hash, const N: usize> Hash for SmallVec<T, N> {
+impl<T: Hash, const N: usize, A: Allocator> Hash for SmallVec<T, N, A> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.as_slice().hash(state)
     }
 }
 
-impl<T, const N: usize> Borrow<[T]> for SmallVec<T, N> {
+impl<T, const N: usize, A: Allocator> Borrow<[T]> for SmallVec<T, N, A> {
     #[inline]
     fn borrow(&self) -> &[T] {
         self.as_slice()
     }
 }
 
-impl<T, const N: usize> BorrowMut<[T]> for SmallVec<T, N> {
+impl<T, const N: usize, A: Allocator> BorrowMut<[T]> for SmallVec<T, N, A> {
     #[inline]
     fn borrow_mut(&mut self) -> &mut [T] {
         self.as_mut_slice()
     }
 }
 
-impl<T, const N: usize> AsRef<[T]> for SmallVec<T, N> {
+impl<T, const N: usize, A: Allocator> AsRef<[T]> for SmallVec<T, N, A> {
     #[inline]
     fn as_ref(&self) -> &[T] {
         self.as_slice()
     }
 }
 
-impl<T, const N: usize> AsMut<[T]> for SmallVec<T, N> {
+impl<T, const N: usize, A: Allocator> AsMut<[T]> for SmallVec<T, N, A> {
     #[inline]
     fn as_mut(&mut self) -> &mut [T] {
         self.as_mut_slice()
     }
 }
 
-impl<T: Debug, const N: usize> Debug for SmallVec<T, N> {
+impl<T: Debug, const N: usize, A: Allocator> Debug for SmallVec<T, N, A> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_list().entries(self.iter()).finish()
     }
 }
 
-impl<T: Debug, const N: usize> Debug for IntoIter<T, N> {
+impl<T: Debug, const N: usize, A: Allocator> Debug for IntoIter<T, N, A> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_tuple("IntoIter").field(&self.as_slice()).finish()
     }
 }
 
-impl<T: Debug, const N: usize> Debug for Drain<'_, T, N> {
+impl<T: Debug, const N: usize, A: Allocator> Debug for Drain<'_, T, N, A> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_tuple("Drain").field(&self.iter.as_slice()).finish()
     }
@@ -3166,7 +3456,7 @@ impl<T: Debug, const N: usize> Debug for Drain<'_, T, N> {
 
 #[cfg(feature = "serde")]
 #[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
-impl<T, const N: usize> Serialize for SmallVec<T, N>
+impl<T, const N: usize, A: Allocator> Serialize for SmallVec<T, N, A>
 where
     T: Serialize,
 {
@@ -3226,7 +3516,7 @@ where
 }
 
 #[cfg(feature = "malloc_size_of")]
-impl<T, const N: usize> MallocShallowSizeOf for SmallVec<T, N> {
+impl<T, const N: usize, A: Allocator> MallocShallowSizeOf for SmallVec<T, N, A> {
     fn shallow_size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
         if self.spilled() {
             unsafe { ops.malloc_size_of(self.as_ptr()) }
@@ -3237,7 +3527,7 @@ impl<T, const N: usize> MallocShallowSizeOf for SmallVec<T, N> {
 }
 
 #[cfg(feature = "malloc_size_of")]
-impl<T: MallocSizeOf, const N: usize> MallocSizeOf for SmallVec<T, N> {
+impl<T: MallocSizeOf, const N: usize, A: Allocator> MallocSizeOf for SmallVec<T, N, A> {
     fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
         let mut n = self.shallow_size_of(ops);
         for elem in self.iter() {
@@ -3249,7 +3539,7 @@ impl<T: MallocSizeOf, const N: usize> MallocSizeOf for SmallVec<T, N> {
 
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl<const N: usize> io::Write for SmallVec<u8, N> {
+impl<const N: usize, A: Allocator> io::Write for SmallVec<u8, N, A> {
     #[inline]
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         self.extend_from_slice(buf);
@@ -3269,7 +3559,7 @@ impl<const N: usize> io::Write for SmallVec<u8, N> {
 }
 
 #[cfg(feature = "bytes")]
-unsafe impl<const N: usize> BufMut for SmallVec<u8, N> {
+unsafe impl<const N: usize, A: Allocator> BufMut for SmallVec<u8, N, A> {
     #[inline]
     fn remaining_mut(&self) -> usize {
         // A vector can never have more than isize::MAX bytes

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1304,7 +1304,7 @@ impl<T, const N: usize, A: Allocator> SmallVec<T, N, A> {
     }
 
     #[inline]
-    pub fn into_raw_parts_with_alloc(self) -> (*mut T, usize, usize, A) {
+    pub fn into_raw_parts_with_allocator(self) -> (*mut T, usize, usize, A) {
         let mut me = ManuallyDrop::new(self);
         let alloc = unsafe { core::ptr::read(me.allocator()) };
         (me.as_mut_ptr(), me.len(), me.capacity(), alloc)
@@ -1386,7 +1386,8 @@ macro_rules! make_heap_methods {
         $into_vec:ident,
         $into_boxed_slice:ident,
         $vec:path,
-        $box:path $(,)?
+        $box:path,
+        $into_raw_parts:ident $(,)?
     ) => {
         impl<T, const N: usize, A: Allocator> SmallVec<T, N, A> {
             #[inline]
@@ -1401,7 +1402,7 @@ macro_rules! make_heap_methods {
                     unsafe { vec.set_len(0) };
                     vec.shrink_to_fit();
 
-                    let (_ptr, _len, _cap, alloc) = vec.into_raw_parts_with_alloc();
+                    let (_ptr, _len, _cap, alloc) = vec.$into_raw_parts();
 
                     Self {
                         len: TaggedLen::new(len, false),
@@ -1409,8 +1410,8 @@ macro_rules! make_heap_methods {
                         _marker: PhantomData,
                     }
                 } else {
-                    // FIXME: Use `into_parts_with_alloc` once it is stable.
-                    let (ptr, len, cap, alloc) = vec.into_raw_parts_with_alloc();
+                    // FIXME: Use `into_parts_with_allocator` once it is stable/available.
+                    let (ptr, len, cap, alloc) = vec.$into_raw_parts();
                     // SAFETY: The pointer of a `Vec` is never null.
                     let ptr = unsafe { NonNull::new_unchecked(ptr) };
 
@@ -1471,6 +1472,7 @@ make_heap_methods! {
     into_boxed_slice,
     Vec<T, A>,
     Box<[T], A>,
+    into_raw_parts_with_allocator,
 }
 
 #[cfg(feature = "allocator-api2")]
@@ -1480,6 +1482,7 @@ make_heap_methods! {
     into_boxed_slice2,
     allocator_api2::vec::Vec<T, A>,
     allocator_api2::boxed::Box<[T], A>,
+    into_raw_parts_with_alloc,
 }
 
 /// Functions for interacting with `std` types whenever

--- a/src/rawsmallvec.rs
+++ b/src/rawsmallvec.rs
@@ -1,3 +1,4 @@
+use super::{Allocator, Global};
 use core::mem::{ManuallyDrop, MaybeUninit};
 use core::ptr::NonNull;
 
@@ -7,7 +8,16 @@ use core::ptr::NonNull;
 /// We store a `NonNull<T>` instead of a `*mut T` so that type is covariant
 /// with respect to `T`, and since the heap pointer is never null.
 #[repr(C)]
-pub union RawSmallVec<T, const N: usize> {
+pub union RawSmallVecUnion<T, const N: usize> {
     pub inline: ManuallyDrop<MaybeUninit<[T; N]>>,
     pub heap: (NonNull<T>, usize),
+}
+
+/// A wrapper around a [`RawSmallVecUnion`] and an allocator.
+/// It is assumed that any pointer inside the `heap` field
+/// was allocated using this allocator.
+#[repr(C)]
+pub struct RawSmallVec<T, const N: usize, A: Allocator = Global> {
+    pub inner: RawSmallVecUnion<T, N>,
+    pub allocator: A,
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -391,14 +391,6 @@ fn test_append() {
 
 #[test]
 #[should_panic]
-fn test_invalid_grow() {
-    let mut v: SmallVec<u8, 8> = SmallVec::new();
-    v.extend(0..8);
-    v.grow(5);
-}
-
-#[test]
-#[should_panic]
 fn drain_overflow() {
     let mut v: SmallVec<u8, 8> = smallvec![0];
     v.drain(..=usize::MAX);
@@ -861,7 +853,7 @@ fn grow_to_shrink() {
     assert!(v.spilled());
     v.clear();
     // Shrink to inline.
-    v.grow(2);
+    v.shrink_to(2);
     assert!(!v.spilled());
     assert_eq!(v.capacity(), 2);
     assert_eq!(v.len(), 0);
@@ -886,20 +878,6 @@ fn resumable_extend() {
 fn uninhabited() {
     enum Void {}
     let _sv = SmallVec::<Void, 8>::new();
-}
-
-#[test]
-fn grow_spilled_same_size() {
-    let mut v: SmallVec<u8, 2> = SmallVec::new();
-    v.push(0);
-    v.push(1);
-    v.push(2);
-    assert!(v.spilled());
-    assert_eq!(v.capacity(), 4);
-    // grow with the same capacity
-    v.grow(4);
-    assert_eq!(v.capacity(), 4);
-    assert_eq!(v[..], [0, 1, 2]);
 }
 
 #[test]


### PR DESCRIPTION
Second attempt at creating custom allocators for `SmallVec`.

This one uses the `allocator-api2` crate (enabled by the feature with the same name) to provide provide access
to allocators in stable Rust. If the feature is disabled, the allocator api provided by nightly Rust is used instead.

Closes #55.
