### PR TITLE
docs: separate repository README

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,18 @@
+# Contributing to rust-smallvec
+
+> [!IMPORTANT]
+> This branch contains the code for SmallVec v2, which is not yet ready for release.
+> If your code is using any of the alpha versions of SmallVec, be aware that the API
+> might change between versions.
+>
+> The status of v2 can be tracked in:
+> - [the milestones](https://github.com/servo/rust-smallvec/milestones)
+> - [the wiki spec](https://github.com/servo/rust-smallvec/wiki)
+>
+> The source code for the latest smallvec 1.x.y release can be found on the
+> [v1 branch](https://github.com/servo/rust-smallvec/tree/v1). Bug fixes for
+> smallvec v1 should be based on that branch, while new feature development should
+> go on the v2 branch.
+
+For user-facing crate documentation, see the root [README](../README.md) and
+[docs.rs](https://docs.rs/smallvec/).

--- a/.github/README.md
+++ b/.github/README.md
@@ -1,18 +1,15 @@
 # Contributing to rust-smallvec
 
-> [!IMPORTANT]
-> This branch contains the code for SmallVec v2, which is not yet ready for release.
-> If your code is using any of the alpha versions of SmallVec, be aware that the API
-> might change between versions.
->
-> The status of v2 can be tracked in:
-> - [the milestones](https://github.com/servo/rust-smallvec/milestones)
-> - [the wiki spec](https://github.com/servo/rust-smallvec/wiki)
->
-> The source code for the latest smallvec 1.x.y release can be found on the
-> [v1 branch](https://github.com/servo/rust-smallvec/tree/v1). Bug fixes for
-> smallvec v1 should be based on that branch, while new feature development should
-> go on the v2 branch.
+This branch contains the code for SmallVec v2, which is not yet ready for release.
+If your code is using any of the alpha versions of SmallVec, be aware that the API
+might change between versions.
 
-For user-facing crate documentation, see the root [README](../README.md) and
-[docs.rs](https://docs.rs/smallvec/).
+The status of v2 can be tracked in:
+
+- [the milestones](https://github.com/servo/rust-smallvec/milestones)
+- [the wiki spec](https://github.com/servo/rust-smallvec/wiki)
+
+The source code for the latest smallvec 1.x.y release can be found on the
+[v1 branch](https://github.com/servo/rust-smallvec/tree/v1). Bug fixes for
+smallvec v1 should be based on that branch, while new feature development should
+go on the v2 branch.

--- a/README.md
+++ b/README.md
@@ -1,20 +1,6 @@
 rust-smallvec
 =============
 
-> [!IMPORTANT]
-> This branch contains the code for SmallVec v2, which is not yet ready for release.
-> If your code is using any of the alpha version of SmallVec, beware that the API might
-> change between versions.
->
-> The status of v2 can be tracked in:
-> - [the milestones](https://github.com/servo/rust-smallvec/milestones)
-> - [the wiki spec](https://github.com/servo/rust-smallvec/wiki)
->
-> The source code for the latest smallvec 1.x.y release can be found on the
-> [v1 branch](https://github.com/servo/rust-smallvec/tree/v1).  
-> Bug fixes for smallvec v1 should be based on that branch, while
-> new feature development should go on the v2 branch.
-
 ## About smallvec
 
 [Documentation](https://docs.rs/smallvec/)


### PR DESCRIPTION
## Summary

- move the v2 development notice from the crates.io README to GitHub's repository README
- keep the root README focused on SmallVec users and published crate documentation

Closes #463.

## Testing

- cargo test
- cargo doc --no-deps

Note: cargo test --all-features requires a nightly compiler because the optional specialization feature is nightly-only.