### PR TITLE
Move unit tests behind the public API boundary

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,8 +66,6 @@ pub extern crate alloc;
 extern crate std;
 
 mod rawsmallvec;
-#[cfg(test)]
-mod tests;
 
 use alloc::alloc::Layout;
 use alloc::boxed::Box;

--- a/tests/smallvec.rs
+++ b/tests/smallvec.rs
@@ -1,10 +1,10 @@
-use crate::{smallvec, SmallVec};
-use alloc::borrow::ToOwned;
-use alloc::boxed::Box;
-use alloc::rc::Rc;
-use alloc::{vec, vec::Vec};
 use core::hash::Hasher;
 use core::iter::FromIterator;
+use smallvec::{smallvec, SmallVec};
+use std::borrow::ToOwned;
+use std::boxed::Box;
+use std::rc::Rc;
+use std::{vec, vec::Vec};
 
 #[test]
 pub fn test_zero() {
@@ -926,10 +926,10 @@ const fn const_new_inner() -> SmallVec<i32, 4> {
     SmallVec::<i32, 4>::new()
 }
 const fn const_new_inline_sized() -> SmallVec<i32, 4> {
-    crate::smallvec_inline![1; 4]
+    smallvec::smallvec_inline![1; 4]
 }
 const fn const_new_inline_args() -> SmallVec<i32, 2> {
-    crate::smallvec_inline![1, 4]
+    smallvec::smallvec_inline![1, 4]
 }
 
 #[test]
@@ -1075,7 +1075,7 @@ fn test_spare_capacity_mut() {
 mod buf_mut {
     use bytes::BufMut as _;
 
-    type SmallVec = crate::SmallVec<u8, 8>;
+    type SmallVec = smallvec::SmallVec<u8, 8>;
 
     #[test]
     fn test_smallvec_as_mut_buf() {


### PR DESCRIPTION
## Summary
- move the main test suite from `src/tests.rs` to `tests/smallvec.rs`
- update imports to consume `smallvec` through its public API
- preserve feature-gated coverage for `std`, `serde`, and `bytes`

This makes API export regressions visible to the test suite instead of compiling the tests as an internal crate module.

Closes #440

## Validation
- `cargo +1.83.0-x86_64-pc-windows-gnu test` (67 integration tests and 6 doctests passed)
- `cargo +stable-x86_64-pc-windows-gnu test` (67 integration tests and 6 doctests passed)
- `cargo +nightly-x86_64-pc-windows-gnu fmt --all --check`
- `cargo +nightly-x86_64-pc-windows-gnu test --all-features` (78 integration tests and 6 doctests passed)
- `cargo +nightly-x86_64-pc-windows-gnu bench --all-features --no-run`
- `git diff --check`