### PR TITLE
docs: cleaner SoC in readme's

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,6 +1,6 @@
 # Contributing to rust-smallvec
 
-This branch containst the code for SmallVec v2, which is on pre-release.
+This branch contains the code for SmallVec v2, which is on pre-release.
 
 Visit [the wiki](https://github.com/servo/rust-smallvec/wiki) for more information about the status and management of v2. Visit it before making any contribution.
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -2,7 +2,7 @@
 
 This branch containst the code for SmallVec v2, which is on pre-release.
 
-Visit [the wiki](https://github.com/servo/rust-smallvec/wiki) for more information about the status and management of v2.
+Visit [the wiki](https://github.com/servo/rust-smallvec/wiki) for more information about the status and management of v2. Visit it before making any contribution.
 
 The source code for the latest smallvec 1.x.y release can be found on the
 [v1 branch](https://github.com/servo/rust-smallvec/tree/v1). Bug fixes for

--- a/.github/README.md
+++ b/.github/README.md
@@ -1,13 +1,8 @@
 # Contributing to rust-smallvec
 
-This branch contains the code for SmallVec v2, which is not yet ready for release.
-If your code is using any of the alpha versions of SmallVec, be aware that the API
-might change between versions.
+This branch containst the code for SmallVec v2, which is on pre-release.
 
-The status of v2 can be tracked in:
-
-- [the milestones](https://github.com/servo/rust-smallvec/milestones)
-- [the wiki spec](https://github.com/servo/rust-smallvec/wiki)
+Visit [the wiki](https://github.com/servo/rust-smallvec/wiki) for more information about the status and management of v2.
 
 The source code for the latest smallvec 1.x.y release can be found on the
 [v1 branch](https://github.com/servo/rust-smallvec/tree/v1). Bug fixes for

--- a/README.md
+++ b/README.md
@@ -1,11 +1,23 @@
-rust-smallvec
-=============
+# rust-smallvec
 
-## About smallvec
-
-[Documentation](https://docs.rs/smallvec/)
-
-[Wiki](https://github.com/servo/rust-smallvec/wiki)
+> [!WARNING]
+> smallvec v2 is on pre-release
+>
+> this means that there might be unexpected changes between versions. see the changelog
+> for detailed breakdowns
+>
+> changes include, but are not limited to:
+> - breaking API changes
+> - deprecation of items
+> - adding, removing or modifying features
+> 
+> beware that this is a pre-release and we can't ensure that there are no vulnerabilities
+> or corner cases. if this feels like a substantial risk to you, please downgrade to the
+> latest v1 version
+> 
+> we are looking for people to test this v2 version, so feel free to play around with
+> smallvec and use it for your purposes if this warning is not a concern, and please file
+> an issue on the repo if you find some unexpected behavior or have a request for a feature
 
 [Release notes](https://github.com/servo/rust-smallvec/releases)
 


### PR DESCRIPTION
this PR rewrites both READMEs to be clearer and target their respective audiences: GitHub visitors and crates.io prospective users

## GitHub

the GitHub readme is simplified to point directly to the wiki, which we can modify much easier than having to make PRs and commits to change on-the-fly documentation 

## crates.io

the crates.io readme now contains a big and explicit warning about v2 being unstable that you can't miss, and also tells people to file issues if they find something wrong