### PR TITLE
Implement `TryFrom<SmallVec<T, N>> for [T; M]`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1668,6 +1668,7 @@ impl<T, const N: usize> SmallVec<T, N> {
     }
 
     #[inline]
+    #[deprecated(since = "2.0.0-alpha.13", note = "use `TryInto::<[T; N]>::into` instead")]
     pub fn into_inner(self) -> Result<[T; N], Self> {
         if self.len() != N {
             Err(self)
@@ -2685,6 +2686,25 @@ impl<T, const N: usize, const M: usize> From<[T; M]> for SmallVec<T, N> {
                 this.set_len(M);
             }
             this
+        }
+    }
+}
+
+impl<T, const N: usize, const M: usize> TryFrom<SmallVec<T, N>> for [T; M] {
+    type Error = SmallVec<T, N>;
+
+    #[inline]
+    fn try_from(mut this: SmallVec<T, N>) -> Result<[T; M], SmallVec<T, N>> {
+        if this.len() != M {
+            Err(this)
+        } else {
+            // SAFETY: we release ownership of the elements we hold
+            unsafe {
+                this.set_len(0);
+            }
+            let ptr = this.as_ptr() as *const [T; M];
+            // SAFETY: these elements are initialized since the length was `M`
+            unsafe { Ok(ptr.read()) }
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1668,7 +1668,10 @@ impl<T, const N: usize> SmallVec<T, N> {
     }
 
     #[inline]
-    #[deprecated(since = "2.0.0-alpha.13", note = "use `TryInto::<[T; N]>::into` instead")]
+    #[deprecated(
+        since = "2.0.0-alpha.13",
+        note = "use `TryInto::<[T; N]>::into` instead"
+    )]
     pub fn into_inner(self) -> Result<[T; N], Self> {
         if self.len() != N {
             Err(self)

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -712,6 +712,26 @@ fn test_into_inner() {
     assert_eq!(vec.clone().into_inner(), Err(vec));
 }
 
+fn test_try_into_array() {
+    // Inline < capacity
+    let vec = SmallVec::<u8, 2>::from_iter(0..1);
+    assert_eq!(<[u8; 0]>::try_from(vec.clone()), Err(vec.clone()));
+    assert_eq!(<[u8; 1]>::try_from(vec.clone()), Ok([0]));
+    assert_eq!(<[u8; 2]>::try_from(vec.clone()), Err(vec));
+
+    // Inline == capacity
+    let vec = SmallVec::<u8, 2>::from_iter(0..2);
+    assert_eq!(<[u8; 1]>::try_from(vec.clone()), Err(vec.clone()));
+    assert_eq!(<[u8; 2]>::try_from(vec.clone()), Ok([0, 1]));
+    assert_eq!(<[u8; 3]>::try_from(vec.clone()), Err(vec));
+
+    // Heap
+    let vec = SmallVec::<u8, 2>::from_iter(0..3);
+    assert_eq!(<[u8; 2]>::try_from(vec.clone()), Err(vec.clone()));
+    assert_eq!(<[u8; 3]>::try_from(vec.clone()), Ok([0, 1, 2]));
+    assert_eq!(<[u8; 4]>::try_from(vec.clone()), Err(vec));
+}
+
 #[test]
 fn test_from_vec() {
     let vec = vec![];


### PR DESCRIPTION
See #357. Also deprecates `into_inner`, since this is a more general version of that function.