### PR TITLE
Implement arbitrary::Arbitrary for SmallVec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -500,6 +506,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 name = "smallvec"
 version = "2.0.0-alpha.12"
 dependencies = [
+ "arbitrary",
  "bytes",
  "criterion",
  "malloc_size_of",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ serde = ["dep:serde_core"]
 internals = []
 
 [dependencies]
+arbitrary = { version = "1", optional = true, default-features = false }
 bytes = { version = "1", optional = true, default-features = false }
 serde_core = { version = "1.0.221", optional = true, default-features = false }
 malloc_size_of = { version = "0.1.1", optional = true, default-features = false }
@@ -28,6 +29,10 @@ malloc_size_of = { version = "0.1.1", optional = true, default-features = false 
 [dev-dependencies]
 serde_test = "1.0"
 criterion = "0.4.0"
+
+[[test]]
+name = "arbitrary"
+required-features = ["arbitrary"]
 
 [[test]]
 name = "bytes"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2978,6 +2978,25 @@ impl<T: Debug, const N: usize> Debug for Drain<'_, T, N> {
     }
 }
 
+#[cfg(feature = "arbitrary")]
+#[cfg_attr(docsrs, doc(cfg(feature = "arbitrary")))]
+impl<'a, T, const N: usize> arbitrary::Arbitrary<'a> for SmallVec<T, N>
+where
+    T: arbitrary::Arbitrary<'a>,
+{
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        u.arbitrary_iter()?.collect()
+    }
+
+    fn arbitrary_take_rest(u: arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        u.arbitrary_take_rest_iter()?.collect()
+    }
+
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        arbitrary::size_hint::and(<usize as arbitrary::Arbitrary>::size_hint(depth), (0, None))
+    }
+}
+
 #[cfg(feature = "serde")]
 #[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl<T, const N: usize> Serialize for SmallVec<T, N>

--- a/tests/arbitrary.rs
+++ b/tests/arbitrary.rs
@@ -1,0 +1,10 @@
+use arbitrary::{Arbitrary, Unstructured};
+use smallvec::SmallVec;
+
+#[test]
+fn test_arbitrary() {
+    // Deterministic for fixed input bytes; assert it builds a consistent SmallVec.
+    let mut u = Unstructured::new(&[0u8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
+    let v = SmallVec::<u8, 4>::arbitrary(&mut u).unwrap();
+    assert_eq!(v.len(), v.iter().count());
+}


### PR DESCRIPTION
Closes #494.

Ports the implementation from the v1 branch to the v2 `SmallVec<T, const N>` API, behind a new optional `arbitrary` feature (gated the same way as `serde`).

- `arbitrary` / `arbitrary_take_rest` delegate to `Unstructured::arbitrary_iter` / `arbitrary_take_rest_iter` and collect via the existing `FromIterator` impl.
- `size_hint` mirrors the standard sequence implementation.
- Adds a feature-gated test (`test_arbitrary`).

Verified locally: `cargo build --features arbitrary`, `cargo test --features arbitrary` (new test passes), and `cargo fmt --check` are all green.