### PR TITLE
Add try_with_capacity fallible constructor

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -849,6 +849,19 @@ impl<T, const N: usize> SmallVec<T, N> {
         this
     }
 
+    /// Constructs a new, empty `SmallVec` with at least the specified capacity,
+    /// returning an error if the allocation fails.
+    ///
+    /// This is the fallible version of [`with_capacity`](Self::with_capacity).
+    #[inline]
+    pub fn try_with_capacity(capacity: usize) -> Result<Self, CollectionAllocErr> {
+        let mut this = Self::new();
+        if capacity > Self::inline_size() {
+            this.try_grow(capacity)?;
+        }
+        Ok(this)
+    }
+
     #[inline]
     pub const fn from_buf<const S: usize>(elements: [T; S]) -> Self {
         const {

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -126,6 +126,19 @@ fn test_with_capacity() {
 }
 
 #[test]
+fn test_try_with_capacity() {
+    let v: SmallVec<u8, 3> = SmallVec::try_with_capacity(1).unwrap();
+    assert!(v.is_empty());
+    assert!(!v.spilled());
+    assert_eq!(v.capacity(), 3);
+
+    let v: SmallVec<u8, 3> = SmallVec::try_with_capacity(10).unwrap();
+    assert!(v.is_empty());
+    assert!(v.spilled());
+    assert_eq!(v.capacity(), 10);
+}
+
+#[test]
 fn drain() {
     let mut v: SmallVec<u8, 2> = SmallVec::new();
     v.push(3);


### PR DESCRIPTION
Closes #416.

Adds `try_with_capacity`, the fallible analogue to `with_capacity`. It mirrors the existing `try_reserve` path: uses `try_grow` and returns `Result<Self, CollectionAllocErr>`.

```rust
pub fn try_with_capacity(capacity: usize) -> Result<Self, CollectionAllocErr>
```

I kept it ungated, matching `try_reserve`/`try_grow` (also ungated). You mentioned it might live behind a feature gate — happy to move it if you'd prefer; just let me know which feature.

Test added in `tests/main.rs` covering the inline and spilled cases.