### PR TITLE
feat: added borsh schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,7 +53,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "553c5d846a6ba5150c65e3b1b8ec073bcf1abc20f9b7220de384a4443ea4e20a"
 dependencies = [
  "borsh-derive",
- "bytes",
  "cfg_aliases",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,7 +52,22 @@ version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "553c5d846a6ba5150c65e3b1b8ec073bcf1abc20f9b7220de384a4443ea4e20a"
 dependencies = [
+ "borsh-derive",
+ "bytes",
  "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12cdfe656708a01f89b451a7d36466e6fe6c414de0aa18fc54f864f6f9ca9f56"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -120,7 +135,7 @@ checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
  "bitflags",
  "clap_lex",
- "indexmap",
+ "indexmap 1.9.3",
  "textwrap",
 ]
 
@@ -238,6 +253,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "futures-core"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -279,6 +300,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -294,7 +321,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07aa2048142242915a31d35844fb311e0e53fcca590c3a0a40dcf1b841fa09eb"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -406,6 +443,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -621,6 +667,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap 2.14.1",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -735,6 +811,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ borsh = ["dep:borsh"]
 
 [dependencies]
 arbitrary = { version = "1.4", optional = true, default-features = false }
-borsh = { version = "1.8", optional = true, features = ["derive", "unstable__schema"], default-features = false}
+borsh = { version = "1.8", optional = true, features = ["derive", "unstable__schema"], default-features = false }
 bytes = { version = "1.12", optional = true, default-features = false }
 defmt = { version = "1.1", optional = true, default-features = false}
 serde_core = { version = "1.0", optional = true, default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,11 @@ specialization = []
 may_dangle = []
 serde = ["dep:serde_core"]
 internals = []
+borsh = ["dep:borsh"]
 
 [dependencies]
 arbitrary = { version = "1.4", optional = true, default-features = false }
-borsh = { version = "1.8", optional = true, features = ["derive", "unstable__schema"]}
+borsh = { version = "1.8", optional = true, features = ["derive", "unstable__schema"], default-features = false}
 bytes = { version = "1.12", optional = true, default-features = false }
 defmt = { version = "1.1", optional = true, default-features = false}
 serde_core = { version = "1.0", optional = true, default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ internals = []
 
 [dependencies]
 arbitrary = { version = "1.4", optional = true, default-features = false }
-borsh = { version = "1.8", optional = true, default-features = false }
+borsh = { version = "1.8", optional = true, features = ["derive", "unstable__schema"]}
 bytes = { version = "1.12", optional = true, default-features = false }
 defmt = { version = "1.1", optional = true, default-features = false}
 serde_core = { version = "1.0", optional = true, default-features = false }

--- a/src/borsh.rs
+++ b/src/borsh.rs
@@ -20,7 +20,7 @@ use {
 
 impl<Type: BorshSerialize, const INLINE: usize> BorshSerialize for SmallVec<Type, INLINE> {
     fn serialize<Writer: Write>(&self, writer: &mut Writer) -> Serial<()> {
-        self.len.0.serialize(writer)?;
+        self.len.value().serialize(writer)?;
         for element in self {
             element.serialize(writer)?;
         }
@@ -30,7 +30,7 @@ impl<Type: BorshSerialize, const INLINE: usize> BorshSerialize for SmallVec<Type
 
 impl<Type: BorshSchema, const INLINE: usize> BorshSchema for SmallVec<Type, INLINE> {
     fn declaration() -> Declaration {
-        return format!("SmallVec<{}, {INLINE}>", Type::declaration());
+        return format!("Vec<{}>", Type::declaration());
     }
 
     fn add_definitions_recursively(definitions: &mut Map<Declaration, Definition>) -> () {
@@ -43,7 +43,7 @@ impl<Type: BorshSchema, const INLINE: usize> BorshSchema for SmallVec<Type, INLI
             declaration,
             Definition::Sequence {
                 length_width: usize::BITS as u8 / 8,
-                length_range: 0..=(isize::MAX as u64),
+                length_range: 0..=(usize::MAX as u64),
                 elements: Type::declaration()
             }
         );

--- a/src/borsh.rs
+++ b/src/borsh.rs
@@ -1,10 +1,19 @@
 use {
     super::SmallVec,
+    alloc::{
+        collections::BTreeMap as Map,
+        format
+    },
     borsh::{
+        BorshSchema,
         BorshSerialize,
         io::{
             Result as Serial,
             Write
+        },
+        schema::{
+            Declaration,
+            Definition
         }
     }
 };
@@ -16,5 +25,27 @@ impl<Type: BorshSerialize, const INLINE: usize> BorshSerialize for SmallVec<Type
             element.serialize(writer)?;
         }
         return Ok(());
+    }
+}
+
+impl<Type: BorshSchema, const INLINE: usize> BorshSchema for SmallVec<Type, INLINE> {
+    fn declaration() -> Declaration {
+        return format!("SmallVec<{}, {INLINE}>", Type::declaration());
+    }
+
+    fn add_definitions_recursively(definitions: &mut Map<Declaration, Definition>) -> () {
+        let declaration = Self::declaration();
+        if definitions.contains_key(&declaration) {
+            return;
+        }
+        Type::add_definitions_recursively(definitions);
+        definitions.insert(
+            declaration,
+            Definition::Sequence {
+                length_width: usize::BITS as u8 / 8,
+                length_range: 0..=(isize::MAX as u64),
+                elements: Type::declaration()
+            }
+        );
     }
 }


### PR DESCRIPTION
this PR implements `borsh::BorshSchema` for `SmallVec`

the `derive` and `unstable__schema` features of `borsh` had to be enabled

closes #503 

## schema

`SmallVec` schema is the same one `Vec` has

it consists of:
- an `usize` for length, that only indicates the amount of items
- all the elements serialized

this PR changes the serialization in order not to serialize the `TaggedLen` directly but it's value. this is important because the schema is only correct if the `usize` represents the amount of elements and not our custom length representation