### PR TITLE
chore: upgraded MSRV to 1.86, edition 2024, and criterion 0.8

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,7 +28,7 @@ jobs:
             toolchain: nightly
             nightly: true
           - name: MSRV
-            toolchain: "1.83.0"
+            toolchain: "1.86.0"
           - name: no_std
             toolchain: stable
             target: thumbv7m-none-eabi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,27 +12,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
 name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
-]
 
 [[package]]
 name = "autocfg"
@@ -72,6 +76,16 @@ name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "cc"
+version = "1.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -114,46 +128,49 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.25"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
- "bitflags",
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
+dependencies = [
+ "anstyle",
  "clap_lex",
- "indexmap",
- "textwrap",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
-]
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "criterion"
-version = "0.4.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c76e09c1aae2bc52b3d2f29e13c6572553b30c4aa1b8a49fd70de6412654cb"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
 dependencies = [
+ "alloca",
  "anes",
- "atty",
  "cast",
  "ciborium",
  "clap",
  "criterion-plot",
  "itertools",
- "lazy_static",
  "num-traits",
  "oorandom",
+ "page_size",
  "plotters",
  "rayon",
  "regex",
  "serde",
- "serde_derive",
  "serde_json",
  "tinytemplate",
  "walkdir",
@@ -161,9 +178,9 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.5.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
  "itertools",
@@ -238,6 +255,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
+
+[[package]]
 name = "futures-core"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -273,35 +296,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown",
-]
-
-[[package]]
 name = "itertools"
-version = "0.10.5"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -322,12 +320,6 @@ dependencies = [
  "futures-util",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
@@ -369,10 +361,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
-name = "os_str_bytes"
-version = "6.6.1"
+name = "page_size"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -543,6 +539,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -583,12 +585,6 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "smallvec"
 version = "2.0.0-alpha.12"
-edition = "2021"
-rust-version = "1.83"
+edition = "2024"
+rust-version = "1.86"
 authors = ["The Servo Project Developers"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/servo/rust-smallvec"
@@ -28,7 +28,7 @@ malloc_size_of = { version = "0.1", optional = true, default-features = false }
 
 [dev-dependencies]
 serde_test = "1.0"
-criterion = "0.4"
+criterion = "0.8"
 
 [[test]]
 name = "arbitrary"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -253,7 +253,7 @@ impl<T, const N: usize> RawSmallVec<T, N> {
     /// The vector must be on the heap
     #[inline]
     const unsafe fn as_ptr_heap(&self) -> *const T {
-        return unsafe {self.heap.0.as_ptr()};
+        return unsafe { self.heap.0.as_ptr() };
     }
 
     /// # Safety
@@ -261,7 +261,7 @@ impl<T, const N: usize> RawSmallVec<T, N> {
     /// The vector must be on the heap
     #[inline]
     const unsafe fn as_mut_ptr_heap(&mut self) -> *mut T {
-        return unsafe {self.heap.0.as_ptr()};
+        return unsafe { self.heap.0.as_ptr() };
     }
 
     /// # Safety
@@ -283,7 +283,7 @@ impl<T, const N: usize> RawSmallVec<T, N> {
 
         let was_on_heap = len.on_heap();
         let ptr = if was_on_heap {
-            unsafe {self.as_mut_ptr_heap()}
+            unsafe { self.as_mut_ptr_heap() }
         } else {
             self.as_mut_ptr_inline()
         };
@@ -297,18 +297,20 @@ impl<T, const N: usize> RawSmallVec<T, N> {
 
         let new_ptr = if !was_on_heap {
             // get a fresh allocation
-            let new_ptr = unsafe {alloc(new_layout)} as *mut T; // `new_layout` has nonzero size.
+            let new_ptr = unsafe { alloc(new_layout) } as *mut T; // `new_layout` has nonzero size.
             let new_ptr = NonNull::new(new_ptr).ok_or(CollectionAllocErr::AllocErr {
                 layout: new_layout
             })?;
-            unsafe {copy_nonoverlapping(ptr, new_ptr.as_ptr(), len)};
+            unsafe { copy_nonoverlapping(ptr, new_ptr.as_ptr(), len) };
             new_ptr
         } else {
             // use realloc
 
             // this can't overflow since we already constructed an equivalent
             // layout during the previous allocation
-            let old_layout = unsafe {Layout::from_size_align_unchecked(self.heap.1 * size_of::<T>(), align_of::<T>())};
+            let old_layout = unsafe {
+                Layout::from_size_align_unchecked(self.heap.1 * size_of::<T>(), align_of::<T>())
+            };
 
             // SAFETY: ptr was allocated with this allocator
             // old_layout is the same as the layout used to allocate the
@@ -316,7 +318,8 @@ impl<T, const N: usize> RawSmallVec<T, N> {
             // than zero does not overflow when rounded up to
             // alignment. since it was constructed
             // with Layout::array
-            let new_ptr = unsafe {realloc(ptr as *mut u8, old_layout, new_layout.size())} as *mut T;
+            let new_ptr =
+                unsafe { realloc(ptr as *mut u8, old_layout, new_layout.size()) } as *mut T;
             NonNull::new(new_ptr).ok_or(CollectionAllocErr::AllocErr {
                 layout: new_layout
             })?
@@ -559,10 +562,12 @@ impl<T, const N: usize> Drain<'_, T, N> {
         };
 
         for place in range_slice {
-            if let Some(new_item) = replace_with.next() {unsafe {
-                core::ptr::write(place, new_item);
-                vec.set_len(vec.len() + 1);
-            }} else {
+            if let Some(new_item) = replace_with.next() {
+                unsafe {
+                    core::ptr::write(place, new_item);
+                    vec.set_len(vec.len() + 1);
+                }
+            } else {
                 return false;
             }
         }
@@ -577,9 +582,9 @@ impl<T, const N: usize> Drain<'_, T, N> {
 
         // Test
         let old_len = vec.len();
-        unsafe {vec.set_len(len)}
+        unsafe { vec.set_len(len) }
         vec.reserve(additional);
-        unsafe {vec.set_len(old_len)};
+        unsafe { vec.set_len(old_len) };
 
         let new_tail_start = self.tail_start + additional;
         unsafe {
@@ -3161,7 +3166,7 @@ unsafe impl<const N: usize> BufMut for SmallVec<u8, N> {
         }
 
         // Addition will not overflow since the sum is at most the capacity.
-        unsafe {self.set_len(len + cnt)};
+        unsafe { self.set_len(len + cnt) };
     }
 
     #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -253,7 +253,7 @@ impl<T, const N: usize> RawSmallVec<T, N> {
     /// The vector must be on the heap
     #[inline]
     const unsafe fn as_ptr_heap(&self) -> *const T {
-        self.heap.0.as_ptr()
+        return unsafe {self.heap.0.as_ptr()};
     }
 
     /// # Safety
@@ -261,7 +261,7 @@ impl<T, const N: usize> RawSmallVec<T, N> {
     /// The vector must be on the heap
     #[inline]
     const unsafe fn as_mut_ptr_heap(&mut self) -> *mut T {
-        self.heap.0.as_ptr()
+        return unsafe {self.heap.0.as_ptr()};
     }
 
     /// # Safety
@@ -283,7 +283,7 @@ impl<T, const N: usize> RawSmallVec<T, N> {
 
         let was_on_heap = len.on_heap();
         let ptr = if was_on_heap {
-            self.as_mut_ptr_heap()
+            unsafe {self.as_mut_ptr_heap()}
         } else {
             self.as_mut_ptr_inline()
         };
@@ -297,19 +297,18 @@ impl<T, const N: usize> RawSmallVec<T, N> {
 
         let new_ptr = if !was_on_heap {
             // get a fresh allocation
-            let new_ptr = alloc(new_layout) as *mut T; // `new_layout` has nonzero size.
+            let new_ptr = unsafe {alloc(new_layout)} as *mut T; // `new_layout` has nonzero size.
             let new_ptr = NonNull::new(new_ptr).ok_or(CollectionAllocErr::AllocErr {
                 layout: new_layout
             })?;
-            copy_nonoverlapping(ptr, new_ptr.as_ptr(), len);
+            unsafe {copy_nonoverlapping(ptr, new_ptr.as_ptr(), len)};
             new_ptr
         } else {
             // use realloc
 
             // this can't overflow since we already constructed an equivalent
             // layout during the previous allocation
-            let old_layout =
-                Layout::from_size_align_unchecked(self.heap.1 * size_of::<T>(), align_of::<T>());
+            let old_layout = unsafe {Layout::from_size_align_unchecked(self.heap.1 * size_of::<T>(), align_of::<T>())};
 
             // SAFETY: ptr was allocated with this allocator
             // old_layout is the same as the layout used to allocate the
@@ -317,7 +316,7 @@ impl<T, const N: usize> RawSmallVec<T, N> {
             // than zero does not overflow when rounded up to
             // alignment. since it was constructed
             // with Layout::array
-            let new_ptr = realloc(ptr as *mut u8, old_layout, new_layout.size()) as *mut T;
+            let new_ptr = unsafe {realloc(ptr as *mut u8, old_layout, new_layout.size())} as *mut T;
             NonNull::new(new_ptr).ok_or(CollectionAllocErr::AllocErr {
                 layout: new_layout
             })?
@@ -560,10 +559,10 @@ impl<T, const N: usize> Drain<'_, T, N> {
         };
 
         for place in range_slice {
-            if let Some(new_item) = replace_with.next() {
-                unsafe { core::ptr::write(place, new_item) };
+            if let Some(new_item) = replace_with.next() {unsafe {
+                core::ptr::write(place, new_item);
                 vec.set_len(vec.len() + 1);
-            } else {
+            }} else {
                 return false;
             }
         }
@@ -578,9 +577,9 @@ impl<T, const N: usize> Drain<'_, T, N> {
 
         // Test
         let old_len = vec.len();
-        vec.set_len(len);
+        unsafe {vec.set_len(len)}
         vec.reserve(additional);
-        vec.set_len(old_len);
+        unsafe {vec.set_len(old_len)};
 
         let new_tail_start = self.tail_start + additional;
         unsafe {
@@ -3162,7 +3161,7 @@ unsafe impl<const N: usize> BufMut for SmallVec<u8, N> {
         }
 
         // Addition will not overflow since the sum is at most the capacity.
-        self.set_len(len + cnt);
+        unsafe {self.set_len(len + cnt)};
     }
 
     #[inline]


### PR DESCRIPTION
this PR upgrades the MSRV to 1.86 with edition 2024

the rationale for this decision is on #493 

closes #493 

it allows us to take advantage of the features introduced with edition 2024, and 1.86 was specifically chosen instead of 1.85 because many features that weren't ready for the release of edition 2024 were stabilized in this version

## changes introduced

1. some `unsafe` blocks had to be added in `lib.rs` since unsafe functions from edition 2024 onwards don't allow unsafe code to be executed without an explicit unsafe block
2. criterion was upgraded to 0.8
3. CI was updated to reflect this change