### PR TITLE
refactor: modularized macros

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,7 @@ extern crate std;
 
 #[cfg(feature = "borsh")]
 mod borsh;
+mod macros;
 mod rawsmallvec;
 
 #[cfg(feature = "bytes")]
@@ -2839,28 +2840,6 @@ impl<T, const N: usize> core::iter::FromIterator<T> for SmallVec<T, N> {
             Self::from_iter_fallback(iter.into_iter())
         }
     }
-}
-
-#[deprecated(since = "2.0.0-alpha.13", note = "use `SmallVec::from` instead")]
-#[macro_export]
-macro_rules! smallvec {
-    ($elem:expr; $n:expr) => ({
-        $crate::from_elem($elem, $n)
-    });
-    ($($($x:expr),+$(,)?)?) => ({
-        $crate::SmallVec::from([$($($x),+)?])
-    });
-}
-
-#[deprecated(since = "2.0.0-alpha.13", note = "use `SmallVec::from_buf` instead")]
-#[macro_export]
-macro_rules! smallvec_inline {
-    ($elem:expr; $n:expr) => ({
-        $crate::SmallVec::<_, $n>::from_buf([$elem; $n])
-    });
-    ($($($x:expr),+$(,)?)?) => ({
-        $crate::SmallVec::from_buf([$($($x),+)?])
-    });
 }
 
 impl<T, const N: usize> IntoIterator for SmallVec<T, N> {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,21 @@
+#[deprecated(since = "2.0.0-alpha.13", note = "use `SmallVec::from` instead")]
+#[macro_export]
+macro_rules! smallvec {
+    ($elem:expr; $n:expr) => ({
+        $crate::from_elem($elem, $n)
+    });
+    ($($($x:expr),+$(,)?)?) => ({
+        $crate::SmallVec::from([$($($x),+)?])
+    });
+}
+
+#[deprecated(since = "2.0.0-alpha.13", note = "use `SmallVec::from_buf` instead")]
+#[macro_export]
+macro_rules! smallvec_inline {
+    ($elem:expr; $n:expr) => ({
+        $crate::SmallVec::<_, $n>::from_buf([$elem; $n])
+    });
+    ($($($x:expr),+$(,)?)?) => ({
+        $crate::SmallVec::from_buf([$($($x),+)?])
+    });
+}


### PR DESCRIPTION
this PR modularizes the macros on `lib.rs` by moving them into `macros.rs`

closes #480 

note: all uses of the macros inside the codebase had already been removed so no other changes have been made