### PR TITLE
refactor: no test-level imports

### DIFF
--- a/tests/main.rs
+++ b/tests/main.rs
@@ -1,12 +1,21 @@
 use {
     core::{
-        hash::Hasher,
+        borrow::{
+            Borrow,
+            BorrowMut
+        },
+        cell::Cell,
+        hash::{
+            Hash,
+            Hasher
+        },
         iter::FromIterator
     },
     smallvec::SmallVec,
     std::{
         borrow::ToOwned,
         boxed::Box,
+        hash::DefaultHasher,
         rc::Rc,
         vec::Vec
     }
@@ -232,8 +241,6 @@ fn into_iter_rev() {
 
 #[test]
 fn into_iter_drop() {
-    use std::cell::Cell;
-
     struct DropCounter<'a>(&'a Cell<i32>);
 
     impl<'a> Drop for DropCounter<'a> {
@@ -492,11 +499,6 @@ fn test_ord() {
 
 #[test]
 fn test_hash() {
-    use std::{
-        collections::hash_map::DefaultHasher,
-        hash::Hash
-    };
-
     fn hash(value: impl Hash) -> u64 {
         let mut hasher = DefaultHasher::new();
         value.hash(&mut hasher);
@@ -544,8 +546,6 @@ fn test_as_mut() {
 
 #[test]
 fn test_borrow() {
-    use std::borrow::Borrow;
-
     let mut a: SmallVec<u32, 2> = SmallVec::new();
     a.push(1);
     assert_eq!(a.borrow(), [1]);
@@ -557,8 +557,6 @@ fn test_borrow() {
 
 #[test]
 fn test_borrow_mut() {
-    use std::borrow::BorrowMut;
-
     let mut a: SmallVec<u32, 2> = SmallVec::new();
     a.push(1);
     assert_eq!(a.borrow_mut(), [1]);

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -1,11 +1,13 @@
-use smallvec::SmallVec;
+use {
+    serde_test::{
+        Token,
+        assert_tokens
+    },
+    smallvec::SmallVec
+};
 
 #[test]
 fn test_serde() {
-    use serde_test::{
-        Token,
-        assert_tokens
-    };
     let mut small_vec: SmallVec<i32, 2> = SmallVec::new();
     assert_tokens(
         &small_vec,

--- a/tests/std.rs
+++ b/tests/std.rs
@@ -1,9 +1,10 @@
-use smallvec::SmallVec;
+use {
+    smallvec::SmallVec,
+    std::io::Write
+};
 
 #[test]
 fn test_write() {
-    use std::io::Write;
-
     let data = [1, 2, 3, 4, 5];
 
     let mut small_vec: SmallVec<u8, 2> = SmallVec::new();


### PR DESCRIPTION
this PR refactors the tests under `tests/*.rs` to only use module-level imports instead of test-level imports

it helps keep the file organized

modules are being split where there are API boundaries, which means that all the tests that share module make use of the same features, and no feature-gated imports are needed

closes #501 