### PR TITLE
style: fn single line

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -34,37 +34,21 @@ trait Vector<T>: for<'a> From<&'a [T]> + Extend<T> {
 }
 
 impl<T: Copy> Vector<T> for Vec<T> {
-    fn new() -> Self {
-        Self::with_capacity(VEC_SIZE)
-    }
+    fn new() -> Self { Self::with_capacity(VEC_SIZE) }
 
-    fn push(&mut self, val: T) {
-        self.push(val)
-    }
+    fn push(&mut self, val: T) { self.push(val) }
 
-    fn pop(&mut self) -> Option<T> {
-        self.pop()
-    }
+    fn pop(&mut self) -> Option<T> { self.pop() }
 
-    fn remove(&mut self, p: usize) -> T {
-        self.remove(p)
-    }
+    fn remove(&mut self, p: usize) -> T { self.remove(p) }
 
-    fn insert(&mut self, n: usize, val: T) {
-        self.insert(n, val)
-    }
+    fn insert(&mut self, n: usize, val: T) { self.insert(n, val) }
 
-    fn from_elem(val: T, n: usize) -> Self {
-        vec![val; n]
-    }
+    fn from_elem(val: T, n: usize) -> Self { vec![val; n] }
 
-    fn from_elems(val: &[T]) -> Self {
-        val.to_owned()
-    }
+    fn from_elems(val: &[T]) -> Self { val.to_owned() }
 
-    fn extend_from_slice(&mut self, other: &[T]) {
-        Vec::extend_from_slice(self, other)
-    }
+    fn extend_from_slice(&mut self, other: &[T]) { Vec::extend_from_slice(self, other) }
 
     fn retain_mut<F>(&mut self, f: F)
     where F: FnMut(&mut T) -> bool {
@@ -73,37 +57,21 @@ impl<T: Copy> Vector<T> for Vec<T> {
 }
 
 impl<T: Copy> Vector<T> for SmallVec<T, VEC_SIZE> {
-    fn new() -> Self {
-        Self::new()
-    }
+    fn new() -> Self { Self::new() }
 
-    fn push(&mut self, val: T) {
-        self.push(val)
-    }
+    fn push(&mut self, val: T) { self.push(val) }
 
-    fn pop(&mut self) -> Option<T> {
-        self.pop()
-    }
+    fn pop(&mut self) -> Option<T> { self.pop() }
 
-    fn remove(&mut self, p: usize) -> T {
-        self.remove(p)
-    }
+    fn remove(&mut self, p: usize) -> T { self.remove(p) }
 
-    fn insert(&mut self, n: usize, val: T) {
-        self.insert(n, val)
-    }
+    fn insert(&mut self, n: usize, val: T) { self.insert(n, val) }
 
-    fn from_elem(val: T, n: usize) -> Self {
-        smallvec![val; n]
-    }
+    fn from_elem(val: T, n: usize) -> Self { smallvec![val; n] }
 
-    fn from_elems(val: &[T]) -> Self {
-        SmallVec::from(val)
-    }
+    fn from_elems(val: &[T]) -> Self { SmallVec::from(val) }
 
-    fn extend_from_slice(&mut self, other: &[T]) {
-        SmallVec::extend_from_slice(self, other)
-    }
+    fn extend_from_slice(&mut self, other: &[T]) { SmallVec::extend_from_slice(self, other) }
 
     fn retain_mut<F>(&mut self, f: F)
     where F: FnMut(&mut T) -> bool {
@@ -191,9 +159,7 @@ make_benches! {
 
 fn gen_push<V: Vector<u64>>(n: u64, b: &mut Bencher) {
     #[inline(never)]
-    fn push_noinline<V: Vector<u64>>(vec: &mut V, x: u64) {
-        vec.push(black_box(x));
-    }
+    fn push_noinline<V: Vector<u64>>(vec: &mut V, x: u64) { vec.push(black_box(x)); }
 
     b.iter(|| {
         let n = black_box(n);
@@ -245,9 +211,7 @@ fn gen_insert<V: Vector<u64>>(n: u64, b: &mut Bencher) {
 
 fn gen_remove<V: Vector<u64>>(n: usize, b: &mut Bencher) {
     #[inline(never)]
-    fn remove_noinline<V: Vector<u64>>(vec: &mut V, p: usize) -> u64 {
-        vec.remove(black_box(p))
-    }
+    fn remove_noinline<V: Vector<u64>>(vec: &mut V, p: usize) -> u64 { vec.remove(black_box(p)) }
 
     b.iter_with_setup(
         || V::from_elem(0, black_box(n)),

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -15,3 +15,4 @@ style_edition = "2024"
 trailing_comma = "Never"
 use_try_shorthand = true
 where_single_line = true
+fn_single_line = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,9 +170,7 @@ fn infallible<T>(result: Result<T, CollectionAllocErr>) -> T {
 
 /// Helper function to check if a type is a ZST.
 #[inline]
-const fn is_zst<T>() -> bool {
-    const { size_of::<T>() == 0 }
-}
+const fn is_zst<T>() -> bool { const { size_of::<T>() == 0 } }
 
 #[inline]
 /// A local copy of [`core::slice::range`]. The latter function is unstable
@@ -214,9 +212,7 @@ impl<T, const N: usize> RawSmallVec<T, N> {
     const IS_ZST: bool = is_zst::<T>();
 
     #[inline]
-    const fn new() -> Self {
-        Self::new_inline(MaybeUninit::uninit())
-    }
+    const fn new() -> Self { Self::new_inline(MaybeUninit::uninit()) }
 
     #[inline]
     const fn new_inline(inline: MaybeUninit<[T; N]>) -> Self {
@@ -252,17 +248,13 @@ impl<T, const N: usize> RawSmallVec<T, N> {
     ///
     /// The vector must be on the heap
     #[inline]
-    const unsafe fn as_ptr_heap(&self) -> *const T {
-        self.heap.0.as_ptr()
-    }
+    const unsafe fn as_ptr_heap(&self) -> *const T { self.heap.0.as_ptr() }
 
     /// # Safety
     ///
     /// The vector must be on the heap
     #[inline]
-    const unsafe fn as_mut_ptr_heap(&mut self) -> *mut T {
-        self.heap.0.as_ptr()
-    }
+    const unsafe fn as_mut_ptr_heap(&mut self) -> *mut T { self.heap.0.as_ptr() }
 
     /// # Safety
     ///
@@ -343,14 +335,10 @@ struct TaggedLen<T>(usize, PhantomData<T>);
 // with the derive attribute implementations.
 impl<T> Clone for TaggedLen<T> {
     #[inline]
-    fn clone(&self) -> Self {
-        Self(self.0, PhantomData)
-    }
+    fn clone(&self) -> Self { Self(self.0, PhantomData) }
 
     #[inline]
-    fn clone_from(&mut self, source: &Self) {
-        self.0 = source.0;
-    }
+    fn clone_from(&mut self, source: &Self) { self.0 = source.0; }
 }
 
 impl<T> Copy for TaggedLen<T> {}
@@ -380,9 +368,7 @@ impl<T> TaggedLen<T> {
     }
 
     #[inline]
-    pub const fn value(self) -> usize {
-        if Self::IS_ZST { self.0 } else { self.0 >> 1 }
-    }
+    pub const fn value(self) -> usize { if Self::IS_ZST { self.0 } else { self.0 >> 1 } }
 }
 
 #[repr(C)]
@@ -397,9 +383,7 @@ unsafe impl<T: Sync, const N: usize> Sync for SmallVec<T, N> {}
 
 impl<T, const N: usize> Default for SmallVec<T, N> {
     #[inline]
-    fn default() -> Self {
-        Self::new()
-    }
+    fn default() -> Self { Self::new() }
 }
 
 /// An iterator that removes the items from a `SmallVec` and yields them by
@@ -435,9 +419,7 @@ impl<'a, T: 'a, const N: usize> Iterator for Drain<'a, T, N> {
     }
 
     #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        self.iter.size_hint()
-    }
+    fn size_hint(&self) -> (usize, Option<usize>) { self.iter.size_hint() }
 }
 
 impl<'a, T: 'a, const N: usize> DoubleEndedIterator for Drain<'a, T, N> {
@@ -452,9 +434,7 @@ impl<'a, T: 'a, const N: usize> DoubleEndedIterator for Drain<'a, T, N> {
 
 impl<T, const N: usize> ExactSizeIterator for Drain<'_, T, N> {
     #[inline]
-    fn len(&self) -> usize {
-        self.iter.len()
-    }
+    fn len(&self) -> usize { self.iter.len() }
 }
 
 impl<T, const N: usize> core::iter::FusedIterator for Drain<'_, T, N> {}
@@ -539,9 +519,7 @@ impl<'a, T: 'a, const N: usize> Drop for Drain<'a, T, N> {
 
 impl<T, const N: usize> Drain<'_, T, N> {
     #[must_use]
-    pub fn as_slice(&self) -> &[T] {
-        self.iter.as_slice()
-    }
+    pub fn as_slice(&self) -> &[T] { self.iter.as_slice() }
 
     /// The range from `self.vec.len` to `self.tail_start` contains elements
     /// that have been moved out.
@@ -657,9 +635,7 @@ where F: FnMut(&mut T) -> bool
         }
     }
 
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        (0, Some(self.end - self.idx))
-    }
+    fn size_hint(&self) -> (usize, Option<usize>) { (0, Some(self.end - self.idx)) }
 }
 
 impl<T, F, const N: usize> Drop for ExtractIf<'_, T, N, F>
@@ -704,19 +680,13 @@ where
 impl<I: Iterator, const N: usize> Iterator for Splice<'_, I, N> {
     type Item = I::Item;
 
-    fn next(&mut self) -> Option<Self::Item> {
-        self.drain.next()
-    }
+    fn next(&mut self) -> Option<Self::Item> { self.drain.next() }
 
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        self.drain.size_hint()
-    }
+    fn size_hint(&self) -> (usize, Option<usize>) { self.drain.size_hint() }
 }
 
 impl<I: Iterator, const N: usize> DoubleEndedIterator for Splice<'_, I, N> {
-    fn next_back(&mut self) -> Option<Self::Item> {
-        self.drain.next_back()
-    }
+    fn next_back(&mut self) -> Option<Self::Item> { self.drain.next_back() }
 }
 
 impl<I: Iterator, const N: usize> ExactSizeIterator for Splice<'_, I, N> {}
@@ -1041,9 +1011,7 @@ impl<T, const N: usize> SmallVec<T, N> {
     ///
     /// The active union member must be the self.raw.heap
     #[inline]
-    unsafe fn set_on_heap(&mut self) {
-        self.len = TaggedLen::new(self.len(), true);
-    }
+    unsafe fn set_on_heap(&mut self) { self.len = TaggedLen::new(self.len(), true); }
 
     /// Sets the tag to be inline
     ///
@@ -1051,9 +1019,7 @@ impl<T, const N: usize> SmallVec<T, N> {
     ///
     /// The active union member must be the self.raw.inline
     #[inline]
-    unsafe fn set_inline(&mut self) {
-        self.len = TaggedLen::new(self.len(), false);
-    }
+    unsafe fn set_inline(&mut self) { self.len = TaggedLen::new(self.len(), false); }
 
     /// Sets the length of a vector.
     ///
@@ -1073,20 +1039,14 @@ impl<T, const N: usize> SmallVec<T, N> {
     }
 
     #[inline]
-    pub const fn inline_size() -> usize {
-        if Self::IS_ZST { usize::MAX } else { N }
-    }
+    pub const fn inline_size() -> usize { if Self::IS_ZST { usize::MAX } else { N } }
 
     #[inline]
-    pub const fn len(&self) -> usize {
-        self.len.value()
-    }
+    pub const fn len(&self) -> usize { self.len.value() }
 
     #[must_use]
     #[inline]
-    pub const fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
+    pub const fn is_empty(&self) -> bool { self.len() == 0 }
 
     #[inline]
     pub const fn capacity(&self) -> usize {
@@ -1099,9 +1059,7 @@ impl<T, const N: usize> SmallVec<T, N> {
     }
 
     #[inline]
-    pub const fn spilled(&self) -> bool {
-        self.len.on_heap()
-    }
+    pub const fn spilled(&self) -> bool { self.len.on_heap() }
 
     /// Splits the collection into two at the given index.
     ///
@@ -1296,9 +1254,7 @@ impl<T, const N: usize> SmallVec<T, N> {
     }
 
     #[inline]
-    pub fn push(&mut self, value: T) {
-        _ = self.push_mut(value);
-    }
+    pub fn push(&mut self, value: T) { _ = self.push_mut(value); }
 
     #[inline]
     #[must_use]
@@ -1375,9 +1331,7 @@ impl<T, const N: usize> SmallVec<T, N> {
     }
 
     #[inline]
-    pub fn grow(&mut self, new_capacity: usize) {
-        infallible(self.try_grow(new_capacity));
-    }
+    pub fn grow(&mut self, new_capacity: usize) { infallible(self.try_grow(new_capacity)); }
 
     #[cold]
     pub fn try_grow(&mut self, new_capacity: usize) -> Result<(), CollectionAllocErr> {
@@ -1605,9 +1559,7 @@ impl<T, const N: usize> SmallVec<T, N> {
     }
 
     #[inline]
-    pub fn insert(&mut self, index: usize, value: T) {
-        _ = self.insert_mut(index, value);
-    }
+    pub fn insert(&mut self, index: usize, value: T) { _ = self.insert_mut(index, value); }
 
     #[inline]
     #[must_use]
@@ -1720,9 +1672,7 @@ impl<T, const N: usize> SmallVec<T, N> {
     }
 
     #[inline]
-    pub fn into_boxed_slice(self) -> Box<[T]> {
-        self.into_vec().into_boxed_slice()
-    }
+    pub fn into_boxed_slice(self) -> Box<[T]> { self.into_vec().into_boxed_slice() }
 
     #[inline]
     #[deprecated(
@@ -1747,9 +1697,7 @@ impl<T, const N: usize> SmallVec<T, N> {
     }
 
     #[inline]
-    pub fn retain<F: FnMut(&T) -> bool>(&mut self, mut f: F) {
-        self.retain_mut(|elem| f(elem))
-    }
+    pub fn retain<F: FnMut(&T) -> bool>(&mut self, mut f: F) { self.retain_mut(|elem| f(elem)) }
 
     #[inline]
     pub fn retain_mut<F: FnMut(&mut T) -> bool>(&mut self, mut f: F) {
@@ -1960,9 +1908,7 @@ impl<T: Clone, const N: usize> SmallVec<T, N> {
     }
 
     #[inline]
-    pub fn extend_from_slice(&mut self, other: &[T]) {
-        self.extend(other.iter())
-    }
+    pub fn extend_from_slice(&mut self, other: &[T]) { self.extend(other.iter()) }
 
     pub fn extend_from_within<R>(&mut self, src: R)
     where R: core::ops::RangeBounds<usize> {
@@ -2175,15 +2121,11 @@ impl<T, const N: usize> core::ops::Deref for SmallVec<T, N> {
     type Target = [T];
 
     #[inline]
-    fn deref(&self) -> &Self::Target {
-        self.as_slice()
-    }
+    fn deref(&self) -> &Self::Target { self.as_slice() }
 }
 impl<T, const N: usize> core::ops::DerefMut for SmallVec<T, N> {
     #[inline]
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        self.as_mut_slice()
-    }
+    fn deref_mut(&mut self) -> &mut Self::Target { self.as_mut_slice() }
 }
 
 /// This function is used in the [`smallvec`] macro.
@@ -2273,9 +2215,7 @@ mod spec_traits {
     where I: Iterator<Item = T>
     {
         #[inline]
-        default fn spec_extend(&mut self, iter: I) {
-            self.extend_fallback(iter);
-        }
+        default fn spec_extend(&mut self, iter: I) { self.extend_fallback(iter); }
     }
 
     impl<T, I, const N: usize> SpecExtend<T, I> for SmallVec<T, N>
@@ -2343,9 +2283,7 @@ mod spec_traits {
         T: Clone
     {
         #[inline]
-        default fn spec_extend(&mut self, iterator: I) {
-            self.spec_extend(iterator.cloned())
-        }
+        default fn spec_extend(&mut self, iterator: I) { self.spec_extend(iterator.cloned()) }
     }
 
     impl<'a, T: 'a, const N: usize> SpecExtend<&'a T, core::slice::Iter<'a, T>> for SmallVec<T, N>
@@ -2433,9 +2371,7 @@ mod spec_traits {
     where I: Iterator<Item = T>
     {
         #[inline]
-        default fn spec_from_iter(iter: I) -> Self {
-            Self::from_iter_fallback(iter)
-        }
+        default fn spec_from_iter(iter: I) -> Self { Self::from_iter_fallback(iter) }
     }
 
     impl<T, I, const N: usize> SpecFromIterator<T, I> for SmallVec<T, N>
@@ -2465,9 +2401,7 @@ mod spec_traits {
 
     impl<T: Clone, const N: usize> SpecCloneFrom<T> for SmallVec<T, N> {
         #[inline]
-        default fn spec_clone_from(&mut self, source: &[T]) {
-            self.clone_from_fallback(source);
-        }
+        default fn spec_clone_from(&mut self, source: &[T]) { self.clone_from_fallback(source); }
     }
 
     impl<T: Copy, const N: usize> SpecCloneFrom<T> for SmallVec<T, N> {
@@ -2704,23 +2638,17 @@ impl<T: Clone, const N: usize> From<&[T]> for SmallVec<T, N> {
 
 impl<T: Clone, const N: usize> From<&mut [T]> for SmallVec<T, N> {
     #[inline]
-    fn from(slice: &mut [T]) -> Self {
-        Self::from(slice as &[T])
-    }
+    fn from(slice: &mut [T]) -> Self { Self::from(slice as &[T]) }
 }
 
 impl<T: Clone, const M: usize, const N: usize> From<&[T; M]> for SmallVec<T, N> {
     #[inline]
-    fn from(slice: &[T; M]) -> Self {
-        Self::from(slice as &[T])
-    }
+    fn from(slice: &[T; M]) -> Self { Self::from(slice as &[T]) }
 }
 
 impl<T: Clone, const M: usize, const N: usize> From<&mut [T; M]> for SmallVec<T, N> {
     #[inline]
-    fn from(slice: &mut [T; M]) -> Self {
-        Self::from(slice as &[T])
-    }
+    fn from(slice: &mut [T; M]) -> Self { Self::from(slice as &[T]) }
 }
 
 impl<T, const N: usize, const M: usize> From<[T; M]> for SmallVec<T, N> {
@@ -2764,16 +2692,12 @@ impl<T, const N: usize, const M: usize> TryFrom<SmallVec<T, N>> for [T; M] {
 }
 
 impl<T, const N: usize> From<Vec<T>> for SmallVec<T, N> {
-    fn from(array: Vec<T>) -> Self {
-        Self::from_vec(array)
-    }
+    fn from(array: Vec<T>) -> Self { Self::from_vec(array) }
 }
 
 impl<T: Clone, const N: usize> Clone for SmallVec<T, N> {
     #[inline]
-    fn clone(&self) -> SmallVec<T, N> {
-        SmallVec::from(self.as_slice())
-    }
+    fn clone(&self) -> SmallVec<T, N> { SmallVec::from(self.as_slice()) }
 
     #[inline]
     fn clone_from(&mut self, source: &Self) {
@@ -2791,9 +2715,7 @@ impl<T: Clone, const N: usize> Clone for SmallVec<T, N> {
 
 impl<T: Clone, const N: usize> Clone for IntoIter<T, N> {
     #[inline]
-    fn clone(&self) -> IntoIter<T, N> {
-        SmallVec::from(self.as_slice()).into_iter()
-    }
+    fn clone(&self) -> IntoIter<T, N> { SmallVec::from(self.as_slice()).into_iter() }
 }
 
 impl<T, const N: usize> Extend<T> for SmallVec<T, N> {
@@ -2888,27 +2810,21 @@ impl<'a, T, const N: usize> IntoIterator for &'a SmallVec<T, N> {
     type IntoIter = core::slice::Iter<'a, T>;
     type Item = &'a T;
 
-    fn into_iter(self) -> Self::IntoIter {
-        self.iter()
-    }
+    fn into_iter(self) -> Self::IntoIter { self.iter() }
 }
 
 impl<'a, T, const N: usize> IntoIterator for &'a mut SmallVec<T, N> {
     type IntoIter = core::slice::IterMut<'a, T>;
     type Item = &'a mut T;
 
-    fn into_iter(self) -> Self::IntoIter {
-        self.iter_mut()
-    }
+    fn into_iter(self) -> Self::IntoIter { self.iter_mut() }
 }
 
 impl<T, U, const N: usize, const M: usize> PartialEq<SmallVec<U, M>> for SmallVec<T, N>
 where T: PartialEq<U>
 {
     #[inline]
-    fn eq(&self, other: &SmallVec<U, M>) -> bool {
-        self.as_slice().eq(other.as_slice())
-    }
+    fn eq(&self, other: &SmallVec<U, M>) -> bool { self.as_slice().eq(other.as_slice()) }
 }
 impl<T, const N: usize> Eq for SmallVec<T, N> where T: Eq {}
 
@@ -2916,45 +2832,35 @@ impl<T, U, const N: usize, const M: usize> PartialEq<[U; M]> for SmallVec<T, N>
 where T: PartialEq<U>
 {
     #[inline]
-    fn eq(&self, other: &[U; M]) -> bool {
-        self[..] == other[..]
-    }
+    fn eq(&self, other: &[U; M]) -> bool { self[..] == other[..] }
 }
 
 impl<T, U, const N: usize, const M: usize> PartialEq<&[U; M]> for SmallVec<T, N>
 where T: PartialEq<U>
 {
     #[inline]
-    fn eq(&self, other: &&[U; M]) -> bool {
-        self[..] == other[..]
-    }
+    fn eq(&self, other: &&[U; M]) -> bool { self[..] == other[..] }
 }
 
 impl<T, U, const N: usize> PartialEq<[U]> for SmallVec<T, N>
 where T: PartialEq<U>
 {
     #[inline]
-    fn eq(&self, other: &[U]) -> bool {
-        self[..] == other[..]
-    }
+    fn eq(&self, other: &[U]) -> bool { self[..] == other[..] }
 }
 
 impl<T, U, const N: usize> PartialEq<&[U]> for SmallVec<T, N>
 where T: PartialEq<U>
 {
     #[inline]
-    fn eq(&self, other: &&[U]) -> bool {
-        self[..] == other[..]
-    }
+    fn eq(&self, other: &&[U]) -> bool { self[..] == other[..] }
 }
 
 impl<T, U, const N: usize> PartialEq<&mut [U]> for SmallVec<T, N>
 where T: PartialEq<U>
 {
     #[inline]
-    fn eq(&self, other: &&mut [U]) -> bool {
-        self[..] == other[..]
-    }
+    fn eq(&self, other: &&mut [U]) -> bool { self[..] == other[..] }
 }
 
 impl<T, const N: usize> PartialOrd for SmallVec<T, N>
@@ -2976,37 +2882,27 @@ where T: Ord
 }
 
 impl<T: Hash, const N: usize> Hash for SmallVec<T, N> {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.as_slice().hash(state)
-    }
+    fn hash<H: Hasher>(&self, state: &mut H) { self.as_slice().hash(state) }
 }
 
 impl<T, const N: usize> Borrow<[T]> for SmallVec<T, N> {
     #[inline]
-    fn borrow(&self) -> &[T] {
-        self.as_slice()
-    }
+    fn borrow(&self) -> &[T] { self.as_slice() }
 }
 
 impl<T, const N: usize> BorrowMut<[T]> for SmallVec<T, N> {
     #[inline]
-    fn borrow_mut(&mut self) -> &mut [T] {
-        self.as_mut_slice()
-    }
+    fn borrow_mut(&mut self) -> &mut [T] { self.as_mut_slice() }
 }
 
 impl<T, const N: usize> AsRef<[T]> for SmallVec<T, N> {
     #[inline]
-    fn as_ref(&self) -> &[T] {
-        self.as_slice()
-    }
+    fn as_ref(&self) -> &[T] { self.as_slice() }
 }
 
 impl<T, const N: usize> AsMut<[T]> for SmallVec<T, N> {
     #[inline]
-    fn as_mut(&mut self) -> &mut [T] {
-        self.as_mut_slice()
-    }
+    fn as_mut(&mut self) -> &mut [T] { self.as_mut_slice() }
 }
 
 impl<T: Debug, const N: usize> Debug for SmallVec<T, N> {
@@ -3139,9 +3035,7 @@ impl<const N: usize> io::Write for SmallVec<u8, N> {
     }
 
     #[inline]
-    fn flush(&mut self) -> io::Result<()> {
-        Ok(())
-    }
+    fn flush(&mut self) -> io::Result<()> { Ok(()) }
 }
 
 #[cfg(feature = "bytes")]
@@ -3198,9 +3092,7 @@ unsafe impl<const N: usize> BufMut for SmallVec<u8, N> {
     }
 
     #[inline]
-    fn put_slice(&mut self, src: &[u8]) {
-        self.extend_from_slice(src);
-    }
+    fn put_slice(&mut self, src: &[u8]) { self.extend_from_slice(src); }
 
     #[inline]
     fn put_bytes(&mut self, val: u8, cnt: usize) {

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -112,9 +112,7 @@ pub fn test_double_spill() {
 
 // https://github.com/servo/rust-smallvec/issues/4
 #[test]
-fn issue_4() {
-    SmallVec::<Box<u32>, 2>::new();
-}
+fn issue_4() { SmallVec::<Box<u32>, 2>::new(); }
 
 // https://github.com/servo/rust-smallvec/issues/5
 #[test]
@@ -237,9 +235,7 @@ fn into_iter_drop() {
     struct DropCounter<'a>(&'a Cell<i32>);
 
     impl<'a> Drop for DropCounter<'a> {
-        fn drop(&mut self) {
-            self.0.set(self.0.get() + 1);
-        }
+        fn drop(&mut self) { self.0.set(self.0.get() + 1); }
     }
 
     {
@@ -890,9 +886,7 @@ fn grow_spilled_same_size() {
 }
 
 #[test]
-fn const_generics() {
-    let _v = SmallVec::<i32, 987>::default();
-}
+fn const_generics() { let _v = SmallVec::<i32, 987>::default(); }
 
 #[test]
 fn const_new() {
@@ -909,20 +903,12 @@ fn const_new() {
     assert_eq!(v[0], 1);
     assert_eq!(v[1], 4);
 }
-const fn const_new_inner() -> SmallVec<i32, 4> {
-    SmallVec::<i32, 4>::new()
-}
-const fn const_new_inline_sized() -> SmallVec<i32, 4> {
-    SmallVec::from_buf([1; 4])
-}
-const fn const_new_inline_args() -> SmallVec<i32, 2> {
-    SmallVec::from_buf([1, 4])
-}
+const fn const_new_inner() -> SmallVec<i32, 4> { SmallVec::<i32, 4>::new() }
+const fn const_new_inline_sized() -> SmallVec<i32, 4> { SmallVec::from_buf([1; 4]) }
+const fn const_new_inline_args() -> SmallVec<i32, 2> { SmallVec::from_buf([1, 4]) }
 
 #[test]
-fn zero_size_items() {
-    SmallVec::<(), 0>::new().push(());
-}
+fn zero_size_items() { SmallVec::<(), 0>::new().push(()); }
 
 #[test]
 fn test_clone_from() {
@@ -999,9 +985,7 @@ fn collect_from_iter() {
     impl<I: Iterator> Iterator for IterNoHint<I> {
         type Item = I::Item;
 
-        fn next(&mut self) -> Option<Self::Item> {
-            self.0.next()
-        }
+        fn next(&mut self) -> Option<Self::Item> { self.0.next() }
 
         // no implementation of size_hint means it returns (0, None) - which
         // forces from_iter to grow the allocated space iteratively.


### PR DESCRIPTION
this PR sets `fn_single_line` to true on `rustfmt.toml`, which makes small functions occupy one line instead of three provided that it does not exceed maximum line column (set to 100)

it saves ~160 LOC in our codebase

the counterargument is that it may compress code and hurt readability