### PR TITLE
refactor: modularize CollectionAllocErr into errors.rs

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,27 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use alloc::alloc::Layout;
+
+/// Error type for APIs with fallible heap allocation
+#[derive(Debug)]
+pub enum CollectionAllocErr {
+    /// Overflow `usize::MAX` or other error during size computation
+    CapacityOverflow,
+    /// The allocator return an error
+    AllocErr {
+        /// The layout that was passed to the allocator
+        layout: Layout,
+    },
+}
+
+impl core::fmt::Display for CollectionAllocErr {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "Allocation error: {:?}", self)
+    }
+}
+
+impl core::error::Error for CollectionAllocErr {}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -4,8 +4,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use alloc::alloc::Layout;
-
 /// Error type for APIs with fallible heap allocation
 #[derive(Debug)]
 pub enum CollectionAllocErr {
@@ -14,7 +12,7 @@ pub enum CollectionAllocErr {
     /// The allocator return an error
     AllocErr {
         /// The layout that was passed to the allocator
-        layout: Layout,
+        layout: alloc::alloc::Layout,
     },
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,10 @@ extern crate std;
 
 #[cfg(feature = "borsh")]
 mod borsh;
+mod errors;
 mod rawsmallvec;
+
+pub use errors::CollectionAllocErr;
 
 #[cfg(feature = "bytes")]
 use bytes::{
@@ -137,25 +140,6 @@ use {
         }
     }
 };
-
-/// Error type for APIs with fallible heap allocation
-#[derive(Debug)]
-pub enum CollectionAllocErr {
-    /// Overflow `usize::MAX` or other error during size computation
-    CapacityOverflow,
-    /// The allocator return an error
-    AllocErr {
-        /// The layout that was passed to the allocator
-        layout: Layout
-    }
-}
-impl core::fmt::Display for CollectionAllocErr {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "Allocation error: {:?}", self)
-    }
-}
-
-impl core::error::Error for CollectionAllocErr {}
 
 #[inline]
 fn infallible<T>(result: Result<T, CollectionAllocErr>) -> T {


### PR DESCRIPTION
## Summary
Modularizes `CollectionAllocErr` as requested in #513.

- Creates `src/errors.rs` containing the `CollectionAllocErr` enum and its `Display`/`Error` implementations
- Removes the same definitions from `src/lib.rs`
- Re-exports the type via `pub use errors::CollectionAllocErr` to preserve the public API

## Testing
- `cargo check` passes
- `cargo test --all-targets` passes (66 tests)
- Verified `CollectionAllocErr` remains accessible as `smallvec::CollectionAllocErr`
- Pre-existing clippy warnings/errors unchanged (verified against base)

Fixes #513