### PR TITLE
refactor: initial `lib.rs` refactor

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,12 @@ extern crate std;
 
 #[cfg(feature = "borsh")]
 mod borsh;
+#[cfg(feature = "malloc_size_of")]
+mod mallocsizeof;
 mod rawsmallvec;
+mod references;
+#[cfg(feature = "serde")]
+mod serde;
 
 #[cfg(feature = "bytes")]
 use bytes::{
@@ -80,43 +85,19 @@ use defmt::{
     Formatter as DeFormatter,
     write as dewrite
 };
-#[cfg(feature = "malloc_size_of")]
-use malloc_size_of::{
-    MallocShallowSizeOf,
-    MallocSizeOf,
-    MallocSizeOfOps
-};
 #[cfg(feature = "internals")]
 pub use rawsmallvec::RawSmallVec;
 #[cfg(not(feature = "internals"))]
 use rawsmallvec::RawSmallVec;
-#[cfg(feature = "serde")]
-use serde_core::{
-    de::{
-        Deserialize,
-        Deserializer,
-        SeqAccess,
-        Visitor
-    },
-    ser::{
-        Serialize,
-        SerializeSeq,
-        Serializer
-    }
-};
 #[cfg(feature = "std")]
 use std::io;
 use {
     alloc::{
-        alloc::Layout,
         boxed::Box,
         vec::Vec
     },
     core::{
-        borrow::{
-            Borrow,
-            BorrowMut
-        },
+        alloc::Layout,
         fmt::Debug,
         hash::{
             Hash,
@@ -2171,21 +2152,6 @@ impl<T, const N: usize> Drop for IntoIter<T, N> {
     }
 }
 
-impl<T, const N: usize> core::ops::Deref for SmallVec<T, N> {
-    type Target = [T];
-
-    #[inline]
-    fn deref(&self) -> &Self::Target {
-        self.as_slice()
-    }
-}
-impl<T, const N: usize> core::ops::DerefMut for SmallVec<T, N> {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        self.as_mut_slice()
-    }
-}
-
 /// This function is used in the [`smallvec`] macro.
 /// It is recommended to use the macro instead of using thís function.
 #[doc(hidden)]
@@ -2981,34 +2947,6 @@ impl<T: Hash, const N: usize> Hash for SmallVec<T, N> {
     }
 }
 
-impl<T, const N: usize> Borrow<[T]> for SmallVec<T, N> {
-    #[inline]
-    fn borrow(&self) -> &[T] {
-        self.as_slice()
-    }
-}
-
-impl<T, const N: usize> BorrowMut<[T]> for SmallVec<T, N> {
-    #[inline]
-    fn borrow_mut(&mut self) -> &mut [T] {
-        self.as_mut_slice()
-    }
-}
-
-impl<T, const N: usize> AsRef<[T]> for SmallVec<T, N> {
-    #[inline]
-    fn as_ref(&self) -> &[T] {
-        self.as_slice()
-    }
-}
-
-impl<T, const N: usize> AsMut<[T]> for SmallVec<T, N> {
-    #[inline]
-    fn as_mut(&mut self) -> &mut [T] {
-        self.as_mut_slice()
-    }
-}
-
 impl<T: Debug, const N: usize> Debug for SmallVec<T, N> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_list().entries(self.iter()).finish()
@@ -3042,84 +2980,6 @@ where T: arbitrary::Arbitrary<'a>
 
     fn size_hint(depth: usize) -> (usize, Option<usize>) {
         arbitrary::size_hint::and(<usize as arbitrary::Arbitrary>::size_hint(depth), (0, None))
-    }
-}
-
-#[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
-impl<T, const N: usize> Serialize for SmallVec<T, N>
-where T: Serialize
-{
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut state = serializer.serialize_seq(Some(self.len()))?;
-        for item in self {
-            state.serialize_element(item)?;
-        }
-        state.end()
-    }
-}
-
-#[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
-impl<'de, T, const N: usize> Deserialize<'de> for SmallVec<T, N>
-where T: Deserialize<'de>
-{
-    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        deserializer.deserialize_seq(SmallVecVisitor {
-            phantom: PhantomData
-        })
-    }
-}
-
-#[cfg(feature = "serde")]
-struct SmallVecVisitor<T, const N: usize> {
-    phantom: PhantomData<T>
-}
-
-#[cfg(feature = "serde")]
-impl<'de, T, const N: usize> Visitor<'de> for SmallVecVisitor<T, N>
-where T: Deserialize<'de>
-{
-    type Value = SmallVec<T, N>;
-
-    fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        formatter.write_str("a sequence")
-    }
-
-    fn visit_seq<B>(self, mut seq: B) -> Result<Self::Value, B::Error>
-    where B: SeqAccess<'de> {
-        use serde_core::de::Error;
-        let len = seq.size_hint().unwrap_or(0);
-        let mut values = SmallVec::new();
-        values.try_reserve(len).map_err(B::Error::custom)?;
-
-        while let Some(value) = seq.next_element()? {
-            values.push(value);
-        }
-
-        Ok(values)
-    }
-}
-
-#[cfg(feature = "malloc_size_of")]
-impl<T, const N: usize> MallocShallowSizeOf for SmallVec<T, N> {
-    fn shallow_size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
-        if self.spilled() {
-            unsafe { ops.malloc_size_of(self.as_ptr()) }
-        } else {
-            0
-        }
-    }
-}
-
-#[cfg(feature = "malloc_size_of")]
-impl<T: MallocSizeOf, const N: usize> MallocSizeOf for SmallVec<T, N> {
-    fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
-        let mut n = self.shallow_size_of(ops);
-        for elem in self.iter() {
-            n += elem.size_of(ops);
-        }
-        n
     }
 }
 

--- a/src/mallocsizeof.rs
+++ b/src/mallocsizeof.rs
@@ -1,0 +1,28 @@
+use {
+    super::SmallVec,
+    malloc_size_of::{
+        MallocShallowSizeOf,
+        MallocSizeOf,
+        MallocSizeOfOps
+    }
+};
+
+impl<T, const N: usize> MallocShallowSizeOf for SmallVec<T, N> {
+    fn shallow_size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
+        if self.spilled() {
+            unsafe { ops.malloc_size_of(self.as_ptr()) }
+        } else {
+            0
+        }
+    }
+}
+
+impl<T: MallocSizeOf, const N: usize> MallocSizeOf for SmallVec<T, N> {
+    fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
+        let mut n = self.shallow_size_of(ops);
+        for elem in self.iter() {
+            n += elem.size_of(ops);
+        }
+        n
+    }
+}

--- a/src/references.rs
+++ b/src/references.rs
@@ -1,0 +1,54 @@
+use {
+    super::SmallVec,
+    core::{
+        borrow::{
+            Borrow,
+            BorrowMut
+        },
+        ops::{
+            Deref,
+            DerefMut
+        }
+    }
+};
+
+impl<T, const N: usize> Borrow<[T]> for SmallVec<T, N> {
+    #[inline]
+    fn borrow(&self) -> &[T] {
+        self.as_slice()
+    }
+}
+impl<T, const N: usize> BorrowMut<[T]> for SmallVec<T, N> {
+    #[inline]
+    fn borrow_mut(&mut self) -> &mut [T] {
+        self.as_mut_slice()
+    }
+}
+
+impl<T, const N: usize> AsRef<[T]> for SmallVec<T, N> {
+    #[inline]
+    fn as_ref(&self) -> &[T] {
+        self.as_slice()
+    }
+}
+impl<T, const N: usize> AsMut<[T]> for SmallVec<T, N> {
+    #[inline]
+    fn as_mut(&mut self) -> &mut [T] {
+        self.as_mut_slice()
+    }
+}
+
+impl<T, const N: usize> Deref for SmallVec<T, N> {
+    type Target = [T];
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        self.as_slice()
+    }
+}
+impl<T, const N: usize> DerefMut for SmallVec<T, N> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.as_mut_slice()
+    }
+}

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,0 +1,68 @@
+use {
+    super::SmallVec,
+    core::marker::PhantomData,
+    serde_core::{
+        de::{
+            Deserialize,
+            Deserializer,
+            SeqAccess,
+            Visitor
+        },
+        ser::{
+            Serialize,
+            SerializeSeq,
+            Serializer
+        }
+    }
+};
+
+#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
+impl<T, const N: usize> Serialize for SmallVec<T, N>
+where T: Serialize
+{
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut state = serializer.serialize_seq(Some(self.len()))?;
+        for item in self {
+            state.serialize_element(item)?;
+        }
+        state.end()
+    }
+}
+
+impl<'de, T, const N: usize> Deserialize<'de> for SmallVec<T, N>
+where T: Deserialize<'de>
+{
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        deserializer.deserialize_seq(SmallVecVisitor {
+            phantom: PhantomData
+        })
+    }
+}
+
+struct SmallVecVisitor<T, const N: usize> {
+    phantom: PhantomData<T>
+}
+
+impl<'de, T, const N: usize> Visitor<'de> for SmallVecVisitor<T, N>
+where T: Deserialize<'de>
+{
+    type Value = SmallVec<T, N>;
+
+    fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        formatter.write_str("a sequence")
+    }
+
+    fn visit_seq<B>(self, mut seq: B) -> Result<Self::Value, B::Error>
+    where B: SeqAccess<'de> {
+        use serde_core::de::Error;
+        let len = seq.size_hint().unwrap_or(0);
+        let mut values = SmallVec::new();
+        values.try_reserve(len).map_err(B::Error::custom)?;
+
+        while let Some(value) = seq.next_element()? {
+            values.push(value);
+        }
+
+        Ok(values)
+    }
+}

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -16,7 +16,6 @@ use {
     }
 };
 
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl<T, const N: usize> Serialize for SmallVec<T, N>
 where T: Serialize
 {


### PR DESCRIPTION
this PR modularizes `lib.rs`, adding the following files:
- `mallocsizeof.rs` => for the `malloc_size_of` feature
- `references.rs` => `AsRef/AsMut` + `Deref/DerefMut` + `Borrow/BorrowMut`
- `serde.rs` => implementations related to the `serde` feature

this PR just moves the implementations there, it does nothing more