### PR TITLE
perf/fix: retain mut algorithm

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,7 +133,8 @@ use {
         ptr::{
             NonNull,
             copy,
-            copy_nonoverlapping
+            copy_nonoverlapping,
+            drop_in_place
         }
     }
 };
@@ -1753,28 +1754,104 @@ impl<T, const N: usize> SmallVec<T, N> {
 
     #[inline]
     pub fn retain_mut<F: FnMut(&mut T) -> bool>(&mut self, mut f: F) {
-        let len = self.len();
+        let original_len = self.len();
 
-        if len == 0 {
-            // return early as hint to llvm, like what std does
+        if original_len == 0 {
+            // Empty case: explicit return allows better optimization, vs
+            // letting compiler infer it
             return;
         }
 
-        let ptr = self.as_mut_ptr();
-        let mut write_idx = 0;
+        // Vec: [Kept, Kept, Hole, Hole, Hole, Hole, Unchecked, Unchecked]
+        //      |            ^- write                ^- read             |
+        //      |<-              original_len                          ->|
+        // Kept: Elements which predicate returns true on.
+        // Hole: Moved or dropped element slot.
+        // Unchecked: Unchecked valid elements.
+        //
+        // This drop guard will be invoked when predicate or `drop` of element
+        // panicked. It shifts unchecked elements to cover holes and
+        // `set_len` to the correct length. In cases when predicate and
+        // `drop` never panic, it will be optimized out.
+        struct PanicGuard<'a, T, const N: usize> {
+            v: &'a mut SmallVec<T, N>,
+            read: usize,
+            write: usize,
+            original_len: usize
+        }
 
-        for read_idx in 0..len {
-            // SAFETY: all the pointers are in bounds
-            unsafe {
-                if f(&mut *ptr.add(read_idx)) {
-                    if write_idx < read_idx {
-                        core::ptr::swap(ptr.add(read_idx), ptr.add(write_idx));
-                    }
-                    write_idx += 1;
+        impl<T, const N: usize> Drop for PanicGuard<'_, T, N> {
+            #[cold]
+            fn drop(&mut self) {
+                let remaining = self.original_len - self.read;
+                // SAFETY: Trailing unchecked items must be valid since we never
+                // touch them.
+                unsafe {
+                    let ptr = self.v.as_mut_ptr();
+                    copy(ptr.add(self.read), ptr.add(self.write), remaining);
+                }
+                // SAFETY: After filling holes, all items are in contiguous
+                // memory.
+                unsafe {
+                    self.v.set_len(self.write + remaining);
                 }
             }
         }
-        self.truncate(write_idx);
+
+        let mut read = 0;
+        loop {
+            // SAFETY: read < original_len
+            let cur = unsafe { self.get_unchecked_mut(read) };
+            if !f(cur) {
+                break;
+            }
+            read += 1;
+            if read == original_len {
+                // All elements are kept, return early.
+                return;
+            }
+        }
+
+        // Critical section starts here and at least one element is going to be
+        // removed. Advance `g.read` early to avoid double drop if
+        // `drop_in_place` panicked.
+        let mut g = PanicGuard {
+            v: self,
+            read: read + 1,
+            write: read,
+            original_len
+        };
+        // SAFETY: previous `read` is always less than original_len.
+        unsafe { drop_in_place(g.v.as_mut_ptr().add(read)) }
+
+        while g.read < g.original_len {
+            let ptr = g.v.as_mut_ptr();
+            // SAFETY: `read` is always less than original_len.
+            let cur = unsafe { &mut *ptr.add(g.read) };
+            if !f(cur) {
+                // Advance `read` early to avoid double drop if `drop_in_place`
+                // panicked.
+                g.read += 1;
+                // SAFETY: We never touch this element again after dropped.
+                unsafe { drop_in_place(cur) };
+            } else {
+                // SAFETY: `read` > `write`, so the slots don't overlap.
+                // We use copy for move, and never touch the source element
+                // again.
+                unsafe {
+                    let hole = ptr.add(g.write);
+                    copy_nonoverlapping(cur, hole, 1);
+                }
+                g.write += 1;
+                g.read += 1;
+            }
+        }
+
+        // We are leaving the critical section and no panic happened,
+        // Commit the length change and forget the guard.
+        // SAFETY: `write` is always less than or equal to original_len.
+        unsafe { g.v.set_len(g.write) };
+        core::mem::forget(g);
     }
 
     #[inline]


### PR DESCRIPTION
Closes #444

* fixes panic behavior to match rust standard library
* improves performance of retain algorithm by reducing memory copies


benchmark results shows about 20-30% performance improvement in cases that retain actually happens:
```
     Running benches/bench.rs (target/release/build/smallvec/5ddccd3aae9f1495/out/bench-5ddccd3aae9f1495)
bench_retain_mut_half   time:   [70.053 ns 70.416 ns 70.873 ns]
                        change: [-31.072% -29.765% -28.409%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  4 (4.00%) high mild
  8 (8.00%) high severe

bench_retain_mut_half_small
                        time:   [34.183 ns 34.212 ns 34.242 ns]
                        change: [+0.8531% +1.0178% +1.1919%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe

bench_retain_mut_all    time:   [27.246 ns 27.261 ns 27.277 ns]
                        change: [-5.8022% -3.9459% -2.4634%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
  2 (2.00%) high severe

bench_retain_mut_all_small
                        time:   [27.199 ns 27.233 ns 27.275 ns]
                        change: [+1.4440% +2.2589% +3.1175%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 22 outliers among 100 measurements (22.00%)
  4 (4.00%) high mild
  18 (18.00%) high severe

bench_retain_mut_none   time:   [27.183 ns 27.202 ns 27.221 ns]
                        change: [-0.6473% -0.2981% +0.0314%] (p = 0.09 > 0.05)
                        No change in performance detected.
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild

bench_retain_mut_none_small
                        time:   [27.180 ns 27.199 ns 27.217 ns]
                        change: [-4.1071% -2.2619% -0.7299%] (p = 0.00 < 0.05)
                        Change within noise threshold.

bench_retain_mut_vec_half
                        time:   [59.931 ns 60.049 ns 60.181 ns]
                        change: [-19.577% -19.106% -18.723%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild

bench_retain_mut_vec_half_small
                        time:   [28.589 ns 28.622 ns 28.662 ns]
                        change: [-3.1025% -2.1240% -1.2223%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe

bench_retain_mut_vec_all
                        time:   [25.772 ns 25.800 ns 25.827 ns]
                        change: [+0.5852% +0.7517% +0.9227%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild
  3 (3.00%) high severe

bench_retain_mut_vec_all_small
                        time:   [25.933 ns 25.965 ns 26.005 ns]
                        change: [+0.8062% +0.9226% +1.0388%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe

bench_retain_mut_vec_none
                        time:   [25.625 ns 25.637 ns 25.651 ns]
                        change: [-1.8376% -1.7440% -1.6515%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

bench_retain_mut_vec_none_small
                        time:   [25.897 ns 25.922 ns 25.948 ns]
                        change: [-0.2309% -0.0278% +0.2089%] (p = 0.82 > 0.05)
                        No change in performance detected.
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) low mild
  1 (1.00%) high mild
  3 (3.00%) high severe
```
