### PR TITLE
docs: stop using deprecated smallvec! macro in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@
 ## Example
 
 ```rust
-use smallvec::{SmallVec, smallvec};
-    
+use smallvec::SmallVec;
+
 // This SmallVec can hold up to 4 items on the stack:
-let mut v: SmallVec<i32, 4> = smallvec![1, 2, 3, 4];
+let mut v: SmallVec<i32, 4> = SmallVec::from([1, 2, 3, 4]);
 
 // It will automatically move its contents to the heap if
 // contains more than four items:


### PR DESCRIPTION
Fixes #518.

## What

The README example still showcased the `smallvec!` macro, which has been deprecated since `2.0.0-alpha.13` (see #445, deprecation notes in `src/lib.rs`: `use SmallVec::from instead`). This PR updates the example to the blessed API:

```rust
let mut v: SmallVec<i32, 4> = SmallVec::from([1, 2, 3, 4]);
```

and drops the macro from the `use` statement. It also removes a line of trailing whitespace that was on the old import line.

## Why

New users copy the README first. Advertising a deprecated macro in the flagship example pushes them toward code that emits deprecation warnings on day one, contradicting the crate's own guidance from #445.

## Verification

- `SmallVec::from([T; M])` is provided by the unconditional `impl<T, const N: usize, const M: usize> From<[T; M]> for SmallVec<T, N>` (`src/lib.rs`, line ~2726) - no feature gate, works in `no_std` core contexts just like the macro did.
- The README block is not a doctest (not `include_str!`-ed into lib.rs), so no test churn; example semantics are unchanged (4 inline elements, spill on `push(5)`).

## Note / possible follow-up

`src/lib.rs` line ~1903 still uses `smallvec![1, 2, 3]` inside a doctested example on `as_mut_ptr` (that one IS compiled by CI). Left out of this PR to keep it docs-only and scoped to #518 - happy to do a follow-up if useful.
