### PR TITLE
chore: remove unsafe warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,10 +146,6 @@ version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
- "bitflags",
- "clap_lex",
- "indexmap 1.9.3",
- "textwrap",
  "clap_builder",
 ]
 
@@ -321,34 +317,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
-]
 
 [[package]]
 name = "indexmap"
@@ -357,7 +328,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07aa2048142242915a31d35844fb311e0e53fcca590c3a0a40dcf1b841fa09eb"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.1",
+ "hashbrown",
 ]
 
 [[package]]
@@ -705,7 +676,7 @@ version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
- "indexmap 2.14.1",
+ "indexmap",
  "toml_datetime",
  "toml_parser",
  "winnow",

--- a/src/rawsmallvec.rs
+++ b/src/rawsmallvec.rs
@@ -70,7 +70,7 @@ impl<T, const N: usize> RawSmallVec<T, N> {
     /// The vector must be on the heap
     #[inline]
     pub const unsafe fn as_ptr_heap(&self) -> *const T {
-        self.heap.0.as_ptr()
+        unsafe { self.heap.0.as_ptr() }
     }
 
     /// # Safety
@@ -78,7 +78,7 @@ impl<T, const N: usize> RawSmallVec<T, N> {
     /// The vector must be on the heap
     #[inline]
     pub const unsafe fn as_mut_ptr_heap(&mut self) -> *mut T {
-        self.heap.0.as_ptr()
+        unsafe { self.heap.0.as_ptr() }
     }
 
     /// # Safety
@@ -100,7 +100,7 @@ impl<T, const N: usize> RawSmallVec<T, N> {
 
         let was_on_heap = len.on_heap();
         let ptr = if was_on_heap {
-            self.as_mut_ptr_heap()
+            unsafe { self.as_mut_ptr_heap() }
         } else {
             self.as_mut_ptr_inline()
         };
@@ -114,19 +114,20 @@ impl<T, const N: usize> RawSmallVec<T, N> {
 
         let new_ptr = if !was_on_heap {
             // get a fresh allocation
-            let new_ptr = alloc(new_layout) as *mut T; // `new_layout` has nonzero size.
+            let new_ptr = unsafe { alloc(new_layout) } as *mut T; // `new_layout` has nonzero size.
             let new_ptr = NonNull::new(new_ptr).ok_or(CollectionAllocErr::AllocErr {
                 layout: new_layout
             })?;
-            copy_nonoverlapping(ptr, new_ptr.as_ptr(), len);
+            unsafe { copy_nonoverlapping(ptr, new_ptr.as_ptr(), len) };
             new_ptr
         } else {
             // use realloc
 
             // this can't overflow since we already constructed an equivalent
             // layout during the previous allocation
-            let old_layout =
-                Layout::from_size_align_unchecked(self.heap.1 * size_of::<T>(), align_of::<T>());
+            let old_layout = unsafe {
+                Layout::from_size_align_unchecked(self.heap.1 * size_of::<T>(), align_of::<T>())
+            };
 
             // SAFETY: ptr was allocated with this allocator
             // old_layout is the same as the layout used to allocate the
@@ -134,7 +135,8 @@ impl<T, const N: usize> RawSmallVec<T, N> {
             // than zero does not overflow when rounded up to
             // alignment. since it was constructed
             // with Layout::array
-            let new_ptr = realloc(ptr as *mut u8, old_layout, new_layout.size()) as *mut T;
+            let new_ptr =
+                unsafe { realloc(ptr as *mut u8, old_layout, new_layout.size()) } as *mut T;
             NonNull::new(new_ptr).ok_or(CollectionAllocErr::AllocErr {
                 layout: new_layout
             })?


### PR DESCRIPTION
this PR adds the missing `unsafe` blocks in unsafe functions in `rawsmallvec.rs` now required by our MSRV