### PR TITLE
feat: added borsh deserialize and tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,10 @@ name = "arbitrary"
 required-features = ["arbitrary"]
 
 [[test]]
+name = "borsh"
+required-features = ["borsh"]
+
+[[test]]
 name = "bytes"
 required-features = ["bytes"]
 

--- a/src/borsh.rs
+++ b/src/borsh.rs
@@ -5,9 +5,12 @@ use {
         format
     },
     borsh::{
+        BorshDeserialize,
         BorshSchema,
         BorshSerialize,
         io::{
+            Error,
+            ErrorKind,
             Result as Serial,
             Write
         },
@@ -15,16 +18,29 @@ use {
             Declaration,
             Definition
         }
-    }
+    },
+    core::iter::repeat_with
 };
 
 impl<Type: BorshSerialize, const INLINE: usize> BorshSerialize for SmallVec<Type, INLINE> {
     fn serialize<Writer: Write>(&self, writer: &mut Writer) -> Serial<()> {
-        self.len.value().serialize(writer)?;
+        (self.len.value() as u64).serialize(writer)?;
         for element in self {
             element.serialize(writer)?;
         }
         return Ok(());
+    }
+}
+
+impl<Type: BorshDeserialize, const INLINE: usize> BorshDeserialize for SmallVec<Type, INLINE> {
+    fn deserialize_reader<R: borsh::io::Read>(reader: &mut R) -> Serial<Self> {
+        let length = u64::deserialize_reader(reader)?;
+        return repeat_with(|| Type::deserialize_reader(reader))
+            .take(length.try_into().map_err(|_| Error::new(
+                ErrorKind::OutOfMemory,
+                "Cannot deserialize a sequence with more than usize::MAX elements in this machine"
+            ))?)
+            .collect();
     }
 }
 
@@ -42,8 +58,8 @@ impl<Type: BorshSchema, const INLINE: usize> BorshSchema for SmallVec<Type, INLI
         definitions.insert(
             declaration,
             Definition::Sequence {
-                length_width: usize::BITS as u8 / 8,
-                length_range: 0..=(usize::MAX as u64),
+                length_width: 8,
+                length_range: 0..=u64::MAX,
                 elements: Type::declaration()
             }
         );

--- a/tests/borsh.rs
+++ b/tests/borsh.rs
@@ -10,7 +10,6 @@ use {
 fn round_trip() -> () {
     let smallvec = SmallVec::<u8, 6>::from([1, 2, 3]);
     let bytes = to_vec(&smallvec).unwrap();
-    assert_eq!(bytes, [3, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3]);
     let new = SmallVec::<u8, 6>::deserialize(&mut bytes.as_ref()).unwrap();
     assert_eq!(new, smallvec);
 }
@@ -19,7 +18,6 @@ fn round_trip() -> () {
 fn round_trip_zst() -> () {
     let smallvec = SmallVec::<(), 5>::from([(); 0x100000]);
     let bytes = to_vec(&smallvec).unwrap();
-    assert_eq!(bytes, [0, 0, 16, 0, 0, 0, 0, 0]);
     let new = SmallVec::<(), 100>::deserialize(&mut bytes.as_ref()).unwrap();
     assert_eq!(new, smallvec);
 }

--- a/tests/borsh.rs
+++ b/tests/borsh.rs
@@ -1,0 +1,25 @@
+use {
+    borsh::{
+        BorshDeserialize,
+        to_vec
+    },
+    smallvec::SmallVec
+};
+
+#[test]
+fn round_trip() -> () {
+    let smallvec = SmallVec::<u8, 6>::from([1, 2, 3]);
+    let bytes = to_vec(&smallvec).unwrap();
+    assert_eq!(bytes, [3, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3]);
+    let new = SmallVec::<u8, 6>::deserialize(&mut bytes.as_ref()).unwrap();
+    assert_eq!(new, smallvec);
+}
+
+#[test]
+fn round_trip_zst() -> () {
+    let smallvec = SmallVec::<(), 5>::from([(); 0x100000]);
+    let bytes = to_vec(&smallvec).unwrap();
+    assert_eq!(bytes, [0, 0, 16, 0, 0, 0, 0, 0]);
+    let new = SmallVec::<(), 100>::deserialize(&mut bytes.as_ref()).unwrap();
+    assert_eq!(new, smallvec);
+}


### PR DESCRIPTION
this PR finishes off the `borsh` feature adding:
- `BorshDeserialize`
- testing

it also changes the wire representation to serialize an `u64` instead of an `usize` for cross-platform compatibility

when targets that are not 64-bits try to deserialize a sequence containing more than `usize::MAX` elements, it returns an error. in 64-bits targets this should be optimized away to a no-op since `u64` always converts to `usize`

closes #485 

closes #522 

closes #291  