### PR TITLE
chore: removed unnecessary borsh feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ specialization = []
 may_dangle = []
 serde = ["dep:serde_core"]
 internals = []
-borsh = ["dep:borsh"]
 
 [dependencies]
 arbitrary = { version = "1.4", optional = true, default-features = false }


### PR DESCRIPTION
this PR removes the unnecessary `borsh` feature from `Cargo.toml`

optional dependencies automatically create a feature with the same name as the dependency if they are not conditionally activated by any other feature