### PR TITLE
fix(deps): pin dependency versions in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,16 +20,16 @@ internals = []
 borsh = ["dep:borsh"]
 
 [dependencies]
-arbitrary = { version = "1.4", optional = true, default-features = false }
-borsh = { version = "1.8", optional = true, features = ["derive", "unstable__schema"], default-features = false }
-bytes = { version = "1.12", optional = true, default-features = false }
-defmt = { version = "1.1", optional = true, default-features = false}
-serde_core = { version = "1.0", optional = true, default-features = false }
-malloc_size_of = { version = "0.1", optional = true, default-features = false }
+arbitrary = { version = "=1.4.2", optional = true, default-features = false }
+borsh = { version = "=1.8.1", optional = true, features = ["derive", "unstable__schema"], default-features = false }
+bytes = { version = "=1.12.1", optional = true, default-features = false }
+defmt = { version = "=1.1.1", optional = true, default-features = false }
+serde_core = { version = "=1.0.229", optional = true, default-features = false }
+malloc_size_of = { version = "=0.1.1", optional = true, default-features = false }
 
 [dev-dependencies]
-serde_test = "1.0"
-criterion = "0.8"
+serde_test = "=1.0.177"
+criterion = "=0.8.2"
 
 [[test]]
 name = "arbitrary"


### PR DESCRIPTION
## Summary
- Pin all dependency versions in `Cargo.toml` to their exact versions from `Cargo.lock`.

## Problem
- `Cargo.toml` uses loose dependency versions, which can allow automatic patch updates and cause unexpected issues.

## Solution
- Updated all dependencies to use exact `=x.y.z` versions matching `Cargo.lock`.

## Related
Closes #532 