### PR TITLE
perf: improved bench settings performance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,16 @@ keywords = ["small", "vec", "vector", "stack", "no_std"]
 categories = ["data-structures"]
 exclude = [".gitignore", "tests/", "fuzz/", "benches/", ".github/"]
 
+[profile.bench]
+lto = "fat"
+codegen-units = 1
+opt-level = 3
+debug = false
+strip = true
+
+[profile.release]
+opt-level = 3
+
 [features]
 std = []
 specialization = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,6 @@ opt-level = 3
 debug = false
 strip = true
 
-[profile.release]
-opt-level = 3
-
 [features]
 std = []
 specialization = []

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -385,8 +385,8 @@ fn bench_macro_from_list_vec(c: &mut Criterion) {
 criterion_group!(
     name = benches;
     config = Criterion::default()
-        .warm_up_time(Duration::from_millis(200))
-        .measurement_time(Duration::from_millis(700));
+        .warm_up_time(Duration::from_millis(400))
+        .measurement_time(Duration::from_millis(1100));
     targets =
     bench_push,
     bench_push_small,


### PR DESCRIPTION
this PR customizes the compile-time profiles in `Cargo.toml` to improve performance

## on bench

it enables LTO, sets codegen units to one, strips debug info, and sets `opt-level` to three

letting the compiler do actual optimization allows us to judge whether codegen has really improved and smallvec is getting faster rather than performance changes being a byproduct of how the compiler decided to transform the code

## bench time

this PR also increases the bench time given how imprecise the measurements could be

closes #515 