### PR TITLE
perf: reduce binary size by optimizing panic formatting

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,6 +169,17 @@ const fn is_zst<T>() -> bool {
 /// and thus cannot be used yet.
 fn slice_range<R>(range: R, bounds: core::ops::RangeTo<usize>) -> core::ops::Range<usize>
 where R: core::ops::RangeBounds<usize> {
+    #[cold]
+    #[inline(never)]
+    #[track_caller]
+    fn assert_failed(start: usize, end: usize, len: usize) -> ! {
+        if start > end {
+            panic!("slice index starts at {start} but ends at {end}");
+        } else {
+            panic!("range end index {end} out of range for slice of length {len}");
+        }
+    }
+
     let len = bounds.end;
 
     let start = match range.start_bound() {
@@ -187,11 +198,8 @@ where R: core::ops::RangeBounds<usize> {
         core::ops::Bound::Unbounded => len
     };
 
-    if start > end {
-        panic!("slice index starts at {start} but ends at {end}");
-    }
-    if end > len {
-        panic!("range end index {end} out of range for slice of length {len}");
+    if start > end || end > len {
+        assert_failed(start, end, len);
     }
 
     core::ops::Range {
@@ -1368,11 +1376,17 @@ impl<T, const N: usize> SmallVec<T, N> {
 
     #[inline]
     pub fn swap_remove(&mut self, index: usize) -> T {
+        #[cold]
+        #[inline(never)]
+        #[track_caller]
+        fn assert_failed(index: usize, len: usize) -> ! {
+            panic!("swap_remove index (is {index}) should be < len (is {len})");
+        }
+
         let len = self.len();
-        assert!(
-            index < len,
-            "swap_remove index (is {index}) should be < len (is {len})"
-        );
+        if index >= len {
+            assert_failed(index, len);
+        }
         // This can't overflow since `len > index >= 0`
         let new_len = len - 1;
         unsafe {
@@ -1403,11 +1417,17 @@ impl<T, const N: usize> SmallVec<T, N> {
 
     #[inline]
     pub fn remove(&mut self, index: usize) -> T {
+        #[cold]
+        #[inline(never)]
+        #[track_caller]
+        fn assert_failed(index: usize, len: usize) -> ! {
+            panic!("removal index (is {index}) should be < len (is {len})");
+        }
+
         let len = self.len();
-        assert!(
-            index < len,
-            "removal index (is {index}) should be < len (is {len})"
-        );
+        if index >= len {
+            assert_failed(index, len);
+        }
         let new_len = len - 1;
         unsafe {
             // SAFETY: new_len < len
@@ -1429,11 +1449,17 @@ impl<T, const N: usize> SmallVec<T, N> {
     #[inline]
     #[must_use]
     pub fn insert_mut(&mut self, index: usize, value: T) -> &mut T {
+        #[cold]
+        #[inline(never)]
+        #[track_caller]
+        fn assert_failed(index: usize, len: usize) -> ! {
+            panic!("insertion index (is {index}) should be <= len (is {len})");
+        }
+
         let len = self.len();
-        assert!(
-            index <= len,
-            "insertion index (is {index}) should be <= len (is {len})"
-        );
+        if index > len {
+            assert_failed(index, len);
+        }
         self.reserve(1);
 
         // SAFETY: `index <= len <= capacity`,


### PR DESCRIPTION
This PR reduces binary size of users by avoiding inlining of rarely executed panic formatting code, methodology is exactly the same as what is used in rust standard library.

`#[cold]` hint is also expected to improve the performance slightly by marking panic path unlikely for the compiler.