### PR TITLE
fix: deprecation note

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1544,7 +1544,7 @@ impl<T, const N: usize> SmallVec<T, N> {
     #[inline]
     #[deprecated(
         since = "2.0.0-alpha.13",
-        note = "use `TryInto::<[T; N]>::into` instead"
+        note = "use `TryInto::<[T; N]>::try_into` instead"
     )]
     pub fn into_inner(self) -> Result<[T; N], Self> {
         if self.len() != N {


### PR DESCRIPTION
this PR fixes the deprecation note for `SmallVec::into_inner`

changed referencing the `into` method to referencing `try_into`, which is the right one

closes #527 