### PR TITLE
docs: add v2 active core contributors

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -8,3 +8,15 @@ The source code for the latest smallvec 1.x.y release can be found on the
 [v1 branch](https://github.com/servo/rust-smallvec/tree/v1). Bug fixes for
 smallvec v1 should be based on that branch, while new feature development should
 go on the v2 branch.
+
+## v2 Active Core Contributors
+
+The following contributors are actively helping advance the v2 development of SmallVec:
+
+- [@fereidani](https://github.com/fereidani)
+- [@TDecking](https://github.com/TDecking)
+- [@bolshoytoster](https://github.com/bolshoytoster)
+
+<a href="https://github.com/servo/rust-smallvec/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=servo/rust-smallvec" />
+</a>


### PR DESCRIPTION
## Summary

- Added a section for the active v2 core contributors.
- Added links to the contributors' GitHub profiles.
- Added the contributors image from contrib.rocks.

## Related

Related to #544 