### PR TITLE
Add rayon support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,10 @@ name = "bytes"
 required-features = ["bytes"]
 
 [[test]]
+name = "rayon"
+required-features = ["rayon"]
+
+[[test]]
 name = "serde"
 required-features = ["serde"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ arbitrary = { version = "1.4", optional = true, default-features = false }
 borsh = { version = "1.8", optional = true, features = ["derive", "unstable__schema"], default-features = false }
 bytes = { version = "1.12", optional = true, default-features = false }
 defmt = { version = "1.1", optional = true, default-features = false }
+rayon = { version = "1", optional = true }
 serde_core = { version = "1.0", optional = true, default-features = false }
 malloc_size_of = { version = "0.1", optional = true, default-features = false }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ arbitrary = { version = "1.4", optional = true, default-features = false }
 borsh = { version = "1.8", optional = true, features = ["derive", "unstable__schema"], default-features = false }
 bytes = { version = "1.12", optional = true, default-features = false }
 defmt = { version = "1.1", optional = true, default-features = false }
-rayon = { version = "1", optional = true }
+rayon = { version = "1.12", optional = true, default-features = false }
 serde_core = { version = "1.0", optional = true, default-features = false }
 malloc_size_of = { version = "0.1", optional = true, default-features = false }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,8 @@ mod macros;
 #[cfg(feature = "malloc_size_of")]
 mod mallocsizeof;
 mod rawsmallvec;
+#[cfg(feature = "rayon")]
+mod rayon;
 mod references;
 #[cfg(feature = "serde")]
 mod serde;

--- a/src/rayon.rs
+++ b/src/rayon.rs
@@ -21,7 +21,7 @@ use {
     }
 };
 
-pub(crate) struct SliceDrain<'a, T>(slice::IterMut<'a, T>);
+struct SliceDrain<'a, T>(slice::IterMut<'a, T>);
 
 impl<T> Iterator for SliceDrain<'_, T> {
     type Item = T;
@@ -82,11 +82,13 @@ impl<T: Send, const N: usize> ParallelIterator for SmallVec<T, N> {
             len,
             DrainProducer(unsafe {
                 // SAFETY: set_len(0) is always valid
-                // All items will either be passed out or dropped by DrainProducer/SliceDrop, so
-                // there shouldn't be any possibility for leakage
+                // All items will either be passed out or dropped by
+                // DrainProducer/SliceDrop, so there shouldn't
+                // be any possibility for leakage
                 self.set_len(0);
 
-                // SAFETY: set_len didn't deallocate/drop the elements, so they are still valid.
+                // SAFETY: set_len didn't deallocate/drop the elements, so they
+                // are still valid.
                 slice::from_raw_parts_mut(self.as_mut_ptr(), len)
             }),
             consumer

--- a/src/rayon.rs
+++ b/src/rayon.rs
@@ -1,0 +1,95 @@
+//! The code is heavily inspired by `rayon/vec.rs`, since it's exactly what we
+//! need, except it's all private
+
+use {
+    crate::SmallVec,
+    core::{
+        mem::take,
+        ptr::{
+            self,
+            drop_in_place
+        },
+        slice
+    },
+    rayon::{
+        iter::plumbing::{
+            Producer,
+            UnindexedConsumer,
+            bridge_producer_consumer
+        },
+        prelude::ParallelIterator
+    }
+};
+
+pub(crate) struct SliceDrain<'a, T>(slice::IterMut<'a, T>);
+
+impl<T> Iterator for SliceDrain<'_, T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<T> {
+        self.0.next().map(|val| unsafe { ptr::read(val) })
+    }
+}
+
+impl<T> DoubleEndedIterator for SliceDrain<'_, T> {
+    fn next_back(&mut self) -> Option<T> {
+        self.0.next_back().map(|val| unsafe { ptr::read(val) })
+    }
+}
+
+impl<T> ExactSizeIterator for SliceDrain<'_, T> {
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+impl<T> Drop for SliceDrain<'_, T> {
+    fn drop(&mut self) {
+        unsafe { drop_in_place(take(&mut self.0).into_slice()) };
+    }
+}
+
+struct DrainProducer<'a, T>(&'a mut [T]);
+
+impl<'a, T: Send> Producer for DrainProducer<'a, T> {
+    type IntoIter = SliceDrain<'a, T>;
+    type Item = T;
+
+    fn into_iter(mut self) -> SliceDrain<'a, T> {
+        SliceDrain(take(&mut self.0).iter_mut())
+    }
+
+    fn split_at(mut self, index: usize) -> (Self, Self) {
+        let (left, right) = take(&mut self.0).split_at_mut(index);
+
+        (DrainProducer(left), DrainProducer(right))
+    }
+}
+
+impl<T> Drop for DrainProducer<'_, T> {
+    fn drop(&mut self) {
+        unsafe { drop_in_place(self.0) };
+    }
+}
+
+impl<T: Send, const N: usize> ParallelIterator for SmallVec<T, N> {
+    type Item = T;
+
+    fn drive_unindexed<C: UnindexedConsumer<T>>(mut self, consumer: C) -> C::Result {
+        let len = self.len();
+
+        bridge_producer_consumer(
+            len,
+            DrainProducer(unsafe {
+                // SAFETY: set_len(0) is always valid
+                // All items will either be passed out or dropped by DrainProducer/SliceDrop, so
+                // there shouldn't be any possibility for leakage
+                self.set_len(0);
+
+                // SAFETY: set_len didn't deallocate/drop the elements, so they are still valid.
+                slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+            }),
+            consumer
+        )
+    }
+}

--- a/tests/rayon.rs
+++ b/tests/rayon.rs
@@ -1,14 +1,15 @@
-#[cfg(not(miri))]
+#![cfg(not(miri))]
+
+use {
+    rayon::{
+        iter::ParallelIterator,
+        prelude::ParallelSlice
+    },
+    smallvec::SmallVec
+};
+
 #[test]
 fn rayon() {
-    use {
-        rayon::{
-            iter::ParallelIterator,
-            prelude::ParallelSlice
-        },
-        smallvec::SmallVec
-    };
-
     assert_eq!(
         [0, 1, 2, 3]
             .par_chunks(2)

--- a/tests/rayon.rs
+++ b/tests/rayon.rs
@@ -1,0 +1,19 @@
+use {
+    rayon::{
+        iter::ParallelIterator,
+        prelude::ParallelSlice
+    },
+    smallvec::SmallVec
+};
+
+#[test]
+fn rayon() {
+    assert_eq!(
+        [0, 1, 2, 3]
+            .par_chunks(2)
+            .map(SmallVec::<i32, 2>::from)
+            .flatten()
+            .collect::<Vec<i32>>(),
+        [0, 1, 2, 3]
+    );
+}

--- a/tests/rayon.rs
+++ b/tests/rayon.rs
@@ -1,13 +1,14 @@
-use {
-    rayon::{
-        iter::ParallelIterator,
-        prelude::ParallelSlice
-    },
-    smallvec::SmallVec
-};
-
+#[cfg(not(miri))]
 #[test]
 fn rayon() {
+    use {
+        rayon::{
+            iter::ParallelIterator,
+            prelude::ParallelSlice
+        },
+        smallvec::SmallVec
+    };
+
     assert_eq!(
         [0, 1, 2, 3]
             .par_chunks(2)


### PR DESCRIPTION
Closes #296.

This is largely based on [`Vec`'s implementation](https://github.com/rayon-rs/rayon/blob/ee0a00bdb1ab039e178a215ad5712fb7fa58e58f/src/vec.rs#L188-L294).

I haven't added any tests yet.