### PR TITLE
ci: update actions/checkout to v7

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,7 +34,7 @@ jobs:
             target: thumbv7m-none-eabi
             no_std: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install packages for fuzzing
         if: matrix.fuzz


### PR DESCRIPTION
## Summary

- Updated `actions/checkout` from v4 to v7 in the rust.yml file.

Closes #550 