### PR TITLE
fix: address review feedback - remove unnecessary Layout import (fixes #513)

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,25 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+/// Error type for APIs with fallible heap allocation
+#[derive(Debug)]
+pub enum CollectionAllocErr {
+    /// Overflow `usize::MAX` or other error during size computation
+    CapacityOverflow,
+    /// The allocator return an error
+    AllocErr {
+        /// The layout that was passed to the allocator
+        layout: alloc::alloc::Layout,
+    },
+}
+
+impl core::fmt::Display for CollectionAllocErr {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "Allocation error: {:?} ", self)
+    }
+}
+
+impl core::error::Error for CollectionAllocErr {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,7 @@ extern crate std;
 
 #[cfg(feature = "borsh")]
 mod borsh;
+mod errors;
 mod comparisons;
 mod conversions;
 mod macros;
@@ -132,24 +133,7 @@ use {
     taggedlen::TaggedLen
 };
 
-/// Error type for APIs with fallible heap allocation
-#[derive(Debug)]
-pub enum CollectionAllocErr {
-    /// Overflow `usize::MAX` or other error during size computation
-    CapacityOverflow,
-    /// The allocator return an error
-    AllocErr {
-        /// The layout that was passed to the allocator
-        layout: Layout
-    }
-}
-impl core::fmt::Display for CollectionAllocErr {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "Allocation error: {:?}", self)
-    }
-}
-
-impl core::error::Error for CollectionAllocErr {}
+pub use errors::CollectionAllocErr;
 
 #[inline]
 fn infallible<T>(result: Result<T, CollectionAllocErr>) -> T {


### PR DESCRIPTION
Addresses review comment from alejandro-vaz on the previous PR #514:

- Creates src/errors.rs with CollectionAllocErr enum and impls  
- Reuses the reviewer-suggested pattern: inline  usage
- Re-exports via `pub use errors::CollectionAllocErr`
- All 6 tests pass