### PR TITLE
Closes #513: modularize error `CollectionAllocErr`

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,20 @@
+use core::alloc::Layout;
+
+/// Error type for APIs with fallible heap allocation
+#[derive(Debug)]
+pub enum CollectionAllocErr {
+    /// Overflow `usize::MAX` or other error during size computation
+    CapacityOverflow,
+    /// The allocator return an error
+    AllocErr {
+        /// The layout that was passed to the allocator
+        layout: Layout
+    }
+}
+impl core::fmt::Display for CollectionAllocErr {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "Allocation error: {:?}", self)
+    }
+}
+
+impl core::error::Error for CollectionAllocErr {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,7 @@ extern crate std;
 mod borsh;
 mod comparisons;
 mod conversions;
+mod errors;
 mod macros;
 #[cfg(feature = "malloc_size_of")]
 mod mallocsizeof;
@@ -132,24 +133,7 @@ use {
     taggedlen::TaggedLen
 };
 
-/// Error type for APIs with fallible heap allocation
-#[derive(Debug)]
-pub enum CollectionAllocErr {
-    /// Overflow `usize::MAX` or other error during size computation
-    CapacityOverflow,
-    /// The allocator return an error
-    AllocErr {
-        /// The layout that was passed to the allocator
-        layout: Layout
-    }
-}
-impl core::fmt::Display for CollectionAllocErr {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "Allocation error: {:?}", self)
-    }
-}
-
-impl core::error::Error for CollectionAllocErr {}
+pub use errors::CollectionAllocErr;
 
 #[inline]
 fn infallible<T>(result: Result<T, CollectionAllocErr>) -> T {


### PR DESCRIPTION
Closes #513.

Verified against the pinned tree: the patch applies cleanly and the issue's post-fix check passes.

Written by an AI coding agent (Sloppy) and opened under my account.

<!-- sloppy-mission-proof:slp_p_rCaFULmdA4H1jCmP-rt36A -->