### PR TITLE
perf: outline and make reserve as cold

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1111,7 +1111,7 @@ impl<T, const N: usize> SmallVec<T, N> {
     pub fn push_mut(&mut self, value: T) -> &mut T {
         let len = self.len();
         if len == self.capacity() {
-            self.reserve(1);
+            self.reserve_cold(1);
         }
 
         // SAFETY: `len < capacity` after the reserve,
@@ -1231,14 +1231,20 @@ impl<T, const N: usize> SmallVec<T, N> {
     pub fn reserve(&mut self, additional: usize) {
         // can't overflow since len <= capacity
         if additional > self.capacity() - self.len() {
-            let new_capacity = infallible(
-                self.len()
-                    .checked_add(additional)
-                    .and_then(usize::checked_next_power_of_two)
-                    .ok_or(CollectionAllocErr::CapacityOverflow)
-            );
-            self.grow(new_capacity);
+            self.reserve_cold(additional);
         }
+    }
+
+    #[cold]
+    #[inline(never)]
+    fn reserve_cold(&mut self, additional: usize) {
+        let new_capacity = infallible(
+            self.len()
+                .checked_add(additional)
+                .and_then(usize::checked_next_power_of_two)
+                .ok_or(CollectionAllocErr::CapacityOverflow)
+        );
+        self.grow(new_capacity);
     }
 
     #[inline]
@@ -1259,13 +1265,19 @@ impl<T, const N: usize> SmallVec<T, N> {
     pub fn reserve_exact(&mut self, additional: usize) {
         // can't overflow since len <= capacity
         if additional > self.capacity() - self.len() {
-            let new_capacity = infallible(
-                self.len()
-                    .checked_add(additional)
-                    .ok_or(CollectionAllocErr::CapacityOverflow)
-            );
-            self.grow(new_capacity);
+            self.reserve_exact_cold(additional);
         }
+    }
+
+    #[cold]
+    #[inline(never)]
+    fn reserve_exact_cold(&mut self, additional: usize) {
+        let new_capacity = infallible(
+            self.len()
+                .checked_add(additional)
+                .ok_or(CollectionAllocErr::CapacityOverflow)
+        );
+        self.grow(new_capacity);
     }
 
     #[inline]
@@ -1441,8 +1453,11 @@ impl<T, const N: usize> SmallVec<T, N> {
         if index > len {
             assert_failed(index, len);
         }
-        self.reserve(1);
 
+        // reserve one if there is no capacity left
+        if len == self.capacity() {
+            self.reserve_cold(1);
+        }
         // SAFETY: `index <= len <= capacity`,
         //         so the offset stays in bounds of the allocation.
         let ptr = unsafe { self.as_mut_ptr().add(index) };


### PR DESCRIPTION
This outlines and mark reserve as cold as it rarely happens during execution of a program.
It helps both with performance and binary size.

Benchmarks results are mixed, some improvements and some regressions, but overall as rust standard library does this too, I think these changes are good for the project:
```
     Running benches/bench.rs (target/release/build/smallvec/30c2fd0ca48816cd/out/bench-30c2fd0ca48816cd)
Gnuplot not found, using plotters backend
bench_push              time:   [382.76 ns 387.09 ns 392.10 ns]
                        change: [+10.972% +13.856% +16.887%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 14 outliers among 100 measurements (14.00%)
  14 (14.00%) high mild

bench_push_small        time:   [47.911 ns 48.409 ns 48.958 ns]
                        change: [−9.7960% −7.7322% −5.6598%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild

bench_insert_push       time:   [460.18 ns 469.63 ns 479.96 ns]
                        change: [+1.5551% +4.3700% +7.4103%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 12 outliers among 100 measurements (12.00%)
  2 (2.00%) high mild
  10 (10.00%) high severe

bench_insert_push_small time:   [58.995 ns 59.779 ns 60.670 ns]
                        change: [+5.9883% +7.1482% +8.4367%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe

bench_pushpop           time:   [316.26 ns 320.23 ns 324.42 ns]
                        change: [−11.452% −9.5607% −7.6188%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe

bench_push_vec          time:   [330.65 ns 334.85 ns 339.32 ns]
                        change: [−4.1151% −3.1676% −2.2502%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe

bench_push_vec_small    time:   [40.818 ns 41.165 ns 41.570 ns]
                        change: [−0.9266% +0.5175% +1.8925%] (p = 0.47 > 0.05)
                        No change in performance detected.
Found 15 outliers among 100 measurements (15.00%)
  15 (15.00%) high mild

bench_insert_push_vec   time:   [415.17 ns 418.68 ns 422.85 ns]
                        change: [−2.4608% −1.2247% +0.0281%] (p = 0.06 > 0.05)
                        No change in performance detected.
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) high mild
  3 (3.00%) high severe

bench_insert_push_vec_small
                        time:   [48.515 ns 48.592 ns 48.681 ns]
                        change: [−12.541% −10.992% −9.6939%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe

bench_pushpop_vec       time:   [262.56 ns 263.35 ns 264.20 ns]
                        change: [−9.0990% −8.2617% −7.4276%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe
```