### PR TITLE
perf: `extend_fallback` optimization

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2547,9 +2547,7 @@ impl<T, const N: usize> SmallVec<T, N> {
     where I: Iterator<Item = T> {
         let (size, _) = iter.size_hint();
         let mut v = Self::with_capacity(size);
-        for x in iter {
-            v.push(x);
-        }
+        v.extend_fallback(iter);
         v
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2449,11 +2449,55 @@ impl<T, const N: usize> SmallVec<T, N> {
 
     fn extend_fallback<I>(&mut self, iter: I)
     where I: IntoIterator<Item = T> {
-        let iter = iter.into_iter();
-        let (size, _) = iter.size_hint();
-        self.reserve(size);
-        for x in iter {
-            self.push(x);
+        struct SetLenOnDrop<'a, T, const N: usize> {
+            vec: &'a mut SmallVec<T, N>,
+            len: usize
+        }
+        impl<T, const N: usize> Drop for SetLenOnDrop<'_, T, N> {
+            #[inline(always)]
+            fn drop(&mut self) {
+                // SAFETY: restores `len` only len of initialized items.
+                unsafe { self.vec.set_len(self.len) };
+            }
+        }
+
+        let mut iter = iter.into_iter();
+        let (lower, _) = iter.size_hint();
+        self.reserve(lower);
+
+        // gaurd will auto drop with return statements inside loop
+        let mut guard = SetLenOnDrop {
+            len: self.len(),
+            vec: self
+        };
+
+        loop {
+            let capacity = guard.vec.capacity();
+            // ptr stays valid until we reserve(memory relocation)
+            let ptr = guard.vec.as_mut_ptr();
+
+            // fast path for when size_hint provides exact length
+            while guard.len < capacity {
+                let Some(value) = iter.next() else { return };
+                // SAFETY: `guard.len < capacity` and slot is uninitialized.
+                unsafe { ptr.add(guard.len).write(value) };
+                guard.len += 1;
+            }
+            // exit happens mostly in the while body `else { return }`,
+            // if we are here iterator is not exact size.
+            let Some(value) = iter.next() else { return };
+            let (lower, _) = iter.size_hint();
+            // restore vector length before requesting reserve
+            // SAFETY: elements up to `guard.len` are initialized.
+            unsafe { guard.vec.set_len(guard.len) };
+            // UNSAFE TO USE `ptr` AFTER THIS POINT.
+            // reserve pessimistic lower+1.
+            guard.vec.reserve(lower.saturating_add(1));
+            // write the currently read value
+            // SAFETY: `reserve` made room for us.
+            unsafe { guard.vec.as_mut_ptr().add(guard.len).write(value) };
+            guard.len += 1;
+            // retry in the fast path
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1726,12 +1726,7 @@ impl<T, const N: usize> SmallVec<T, N> {
     where F: FnMut() -> T {
         let old_len = self.len();
         if old_len < new_len {
-            let mut f = f;
-            let additional = new_len - old_len;
-            self.reserve(additional);
-            for _ in 0..additional {
-                self.push(f());
-            }
+            self.extend(core::iter::repeat_with(f).take(new_len - old_len));
         } else if old_len > new_len {
             self.truncate(new_len);
         }


### PR DESCRIPTION
This optimizes `extend_fallback` with some unsafe code. I tried to document the unsafe behavior as much as possible to avoid future mistakes.

Benchmark results:
```
bench_extend            time:   [34.645 ns 34.823 ns 34.999 ns]
                        change: [−74.574% −74.269% −74.003%] (p = 0.00 < 0.05)
                        Performance has improved.

bench_extend_small      time:   [20.678 ns 20.851 ns 21.036 ns]
                        change: [−44.092% −42.884% −41.620%] (p = 0.00 < 0.05)
                        Performance has improved.

bench_extend_filtered   time:   [117.77 ns 118.27 ns 118.79 ns]
                        change: [−32.519% −32.049% −31.581%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) low mild
  2 (2.00%) high mild

bench_extend_filtered_small
                        time:   [22.823 ns 23.030 ns 23.247 ns]
                        change: [−35.161% −33.879% −32.470%] (p = 0.00 < 0.05)
                        Performance has improved.

bench_extend_from_slice time:   [36.363 ns 36.499 ns 36.644 ns]
                        change: [−74.015% −73.725% −73.444%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high severe

bench_extend_from_slice_small
                        time:   [20.650 ns 20.784 ns 20.940 ns]
                        change: [−43.591% −42.283% −40.916%] (p = 0.00 < 0.05)
                        Performance has improved.

bench_extend_vec        time:   [60.429 ns 60.616 ns 60.839 ns]
                        change: [−10.449% −9.9262% −9.3862%] (p = 0.00 < 0.05)
                        Performance has improved.

bench_extend_vec_small  time:   [18.259 ns 18.324 ns 18.391 ns]
                        change: [+0.2642% +0.9616% +1.6561%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high severe

bench_extend_vec_filtered
                        time:   [150.21 ns 150.63 ns 151.08 ns]
                        change: [+5.9960% +6.5508% +7.0910%] (p = 0.00 < 0.05)
                        Performance has regressed.

bench_extend_vec_filtered_small
                        time:   [18.556 ns 18.663 ns 18.779 ns]
                        change: [−3.2075% −2.4870% −1.8235%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

bench_extend_from_slice_vec
                        time:   [62.906 ns 63.110 ns 63.350 ns]
                        change: [−1.0367% −0.5490% −0.0662%] (p = 0.03 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

bench_extend_from_slice_vec_small
                        time:   [18.380 ns 18.463 ns 18.569 ns]
                        change: [+3.8765% +6.5163% +9.4532%] (p = 0.00 < 0.05)
                        Performance has regressed.

```