### PR TITLE
docs: added feature descriptions to README

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,11 +19,12 @@ debug = false
 strip = true
 
 [features]
-std = []
-specialization = []
-may_dangle = []
-serde = ["dep:serde_core"]
 internals = []
+may_dangle = []
+rayon = ["std", "dep:rayon"]
+serde = ["dep:serde_core"]
+specialization = []
+std = []
 
 [dependencies]
 arbitrary = { version = "1.4", optional = true, default-features = false }

--- a/README.md
+++ b/README.md
@@ -21,7 +21,10 @@
 
 [Release notes](https://github.com/servo/rust-smallvec/releases)
 
-"Small vector" optimization for Rust: store up to a small number of items on the stack
+Small vectors in various sizes. These store a certain number of elements
+inline, and fall back to the heap for larger allocations.  This can be a
+useful optimization for improving cache locality and reducing allocator
+traffic for workloads that fit within the inline buffer.
 
 ## Example
 
@@ -40,3 +43,22 @@ v.push(5);
 v[0] = v[1] + v[2];
 v.sort();
 ```
+
+## Feature List
+
+By default, SmallVec does not make use of any feature. SmallVec without any features enabled does not make use of the standard library.
+
+- `arbitrary`: implements `Arbitrary` for any `SmallVec` storing elements that implement `Arbitrary`
+- `borsh`: implements `BorshSerialize`, `BorshDeserialize` and `BorshSchema`
+- `bytes`: implements `BufMut` for SmallVec
+- `defmt`: implements `defmt::Format` for SmallVec
+- `encase`: implements encasing as a runtime-sized array
+- `internals`: exports through the public API `TaggedLen` and `RawSmallVec`
+- `malloc_size_of`: implements `MallocSizeOf` and `MallocShallowSizeOf`
+- `may_dangle` (nightly): enables the eyepatch optimization for dropping
+- `rayon`: implements parallel iteration
+- `serde`: implements serde's serialization and deserialization
+- `specialization` (nightly): enables specialization, improving performance on some cases
+- `std`: implements the `std::io::Write` type for `SmallVec<u8, N>`
+
+> The `rayon` feature implicitly requires `std`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,69 +4,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! Small vectors in various sizes. These store a certain number of elements
-//! inline, and fall back to the heap for larger allocations.  This can be a
-//! useful optimization for improving cache locality and reducing allocator
-//! traffic for workloads that fit within the inline buffer.
-//!
-//! ## `no_std` support
-//!
-//! By default, `smallvec` does not depend on `std`.  However, the optional
-//! `write` feature implements the `std::io::Write` trait for vectors of `u8`.
-//! When this feature is enabled, `smallvec` depends on `std`.
-//!
-//! ## Optional features
-//!
-//! ### `std`
-//!
-//! When this feature is enabled, traits available from `std` are implemented:
-//!
-//! * `SmallVec<u8, _>` implements the [`std::io::Write`] trait.
-//! * [`CollectionAllocErr`] implements [`std::error::Error`].
-//!
-//! This feature is not compatible with `#![no_std]` programs.
-//!
-//! ### `serde`
-//!
-//! When this optional dependency is enabled, `SmallVec` implements the
-//! `serde::Serialize` and `serde::Deserialize` traits.
-//!
-//! ### `specialization`
-//!
-//! **This feature is unstable and requires a nightly build of the Rust
-//! toolchain.**
-//!
-//! When this feature is enabled, `SmallVec::from(slice)` has improved
-//! performance for slices of `Copy` types.  (Without this feature, you can use
-//! `SmallVec::from_slice` to get optimal performance for `Copy` types.)
-//!
-//! Tracking issue: [rust-lang/rust#31844](https://github.com/rust-lang/rust/issues/31844)
-//!
-//! ### `may_dangle`
-//!
-//! **This feature is unstable and requires a nightly build of the Rust
-//! toolchain.**
-//!
-//! This feature makes the Rust compiler less strict about use of vectors that
-//! contain borrowed references. For details, see the
-//! [Rustonomicon](https://doc.rust-lang.org/1.42.0/nomicon/dropck.html#an-escape-hatch).
-//!
-//! Tracking issue: [rust-lang/rust#34761](https://github.com/rust-lang/rust/issues/34761)
-//!
-//! ### `encase`
-//!
-//! When this optional dependency is enabled, `SmallVec` implements `encase`'s
-//! traits.
+#![doc = include_str!("../README.md")]
 
 #![no_std]
+
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(feature = "specialization", allow(incomplete_features))]
 #![cfg_attr(feature = "specialization", feature(specialization, trusted_len))]
 #![cfg_attr(feature = "may_dangle", feature(dropck_eyepatch))]
 
-#[doc(hidden)]
 extern crate alloc;
-
 #[cfg(feature = "std")]
 extern crate std;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,9 +5,7 @@
 // except according to those terms.
 
 #![doc = include_str!("../README.md")]
-
 #![no_std]
-
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(feature = "specialization", allow(incomplete_features))]
 #![cfg_attr(feature = "specialization", feature(specialization, trusted_len))]


### PR DESCRIPTION
this PR adds the features descriptions to `README.md`, and then links the file as documentation for the crate

## other changes

- reorganizes imports
- removes an unnecessary `doc(hidden)` for `alloc`
- changes the `rayon` feature to require `std` since `rayon` is not a `#![no_std]` crate