### PR TITLE
fix: cargo warnings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -985,9 +985,9 @@ impl<A: Array> SmallVec<A> {
             // `Vec` also does this:
             // https://github.com/rust-lang/rust/blob/1.44.0/src/liballoc/raw_vec.rs#L186
             //
-            // In our case, this also ensures that a smallvec of zero-size items never
-            // spills, and we never try to allocate zero bytes which
-            // `std::alloc::alloc` disallows.
+            // In our case, this also ensures that a smallvec of zero-size items
+            // never spills, and we never try to allocate zero bytes
+            // which `std::alloc::alloc` disallows.
             #[allow(deprecated)]
             core::usize::MAX
         }
@@ -1492,7 +1492,9 @@ impl<A: Array> SmallVec<A> {
 
         let (lower_size_bound, _) = iter.size_hint();
         #[allow(deprecated)]
-        {assert!(lower_size_bound <= core::isize::MAX as usize)} // Ensure offset is indexable
+        {
+            assert!(lower_size_bound <= core::isize::MAX as usize)
+        } // Ensure offset is indexable
         assert!(index + lower_size_bound >= index); // Protect against overflow
 
         let mut num_added = 0;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -980,6 +980,7 @@ impl<A: Array> SmallVec<A> {
             // In our case, this also ensures that a smallvec of zero-size items never
             // spills, and we never try to allocate zero bytes which
             // `std::alloc::alloc` disallows.
+            #[allow(deprecated)]
             core::usize::MAX
         }
     }
@@ -1469,7 +1470,8 @@ impl<A: Array> SmallVec<A> {
         }
 
         let (lower_size_bound, _) = iter.size_hint();
-        assert!(lower_size_bound <= core::isize::MAX as usize); // Ensure offset is indexable
+        #[allow(deprecated)]
+        {assert!(lower_size_bound <= core::isize::MAX as usize)} // Ensure offset is indexable
         assert!(index + lower_size_bound >= index); // Protect against overflow
 
         let mut num_added = 0;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -434,6 +434,7 @@ fn test_invalid_grow() {
 #[should_panic]
 fn drain_overflow() {
     let mut v: SmallVec<[u8; 8]> = smallvec![0];
+    #[allow(deprecated)]
     v.drain(..=std::usize::MAX);
 }
 


### PR DESCRIPTION
this PR fixes the `cargo` warnings on v1 by allowing the deprecated uses of constants