### PR TITLE
chore: bump version to 1.16.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smallvec"
-version = "1.16.0"
+version = "1.16.1"
 edition = "2018"
 authors = ["The Servo Project Developers"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Closes #584.

Bumps the v1 branch package version from 1.16.0 to 1.16.1 as requested.

Validated with the relevant upstream matrix commands:

- `cargo fmt --all --check`
- `cargo test --verbose`
- `cargo test --verbose --features serde`
- `cargo test --verbose --features malloc_size_of`
- `cargo check --verbose --no-default-features`
- `cargo test --verbose --features union`
- `cargo +nightly test --verbose --all-features`