### PR TITLE
Splice and push_mut/insert_mut undefined behavior fix

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -361,23 +361,17 @@ impl<T, const N: usize> Drain<'_, T, N> {
     /// range. (`replace_with.next()` didn’t return `None`.)
     unsafe fn fill<I: Iterator<Item = T>>(&mut self, replace_with: &mut I) -> bool {
         let vec = unsafe { self.vec.as_mut() };
-        let range_start = vec.len();
         let range_end = self.tail_start;
-        let range_slice = unsafe {
-            core::slice::from_raw_parts_mut(
-                vec.as_mut_ptr().add(range_start),
-                range_end - range_start
-            )
-        };
 
-        for place in range_slice {
-            if let Some(new_item) = replace_with.next() {
-                unsafe {
-                    core::ptr::write(place, new_item);
-                    vec.len.add(1);
-                }
-            } else {
+        while vec.len() < range_end {
+            let Some(new_item) = replace_with.next() else {
                 return false;
+            };
+            let len = vec.len();
+            // SAFETY: len < tail_start <= capacity
+            unsafe {
+                vec.as_mut_ptr().add(len).write(new_item);
+                vec.set_len(len + 1);
             }
         }
         true
@@ -397,9 +391,12 @@ impl<T, const N: usize> Drain<'_, T, N> {
 
         let new_tail_start = self.tail_start + additional;
         unsafe {
-            let src = vec.as_ptr().add(self.tail_start);
-            let dst = vec.as_mut_ptr().add(new_tail_start);
-            core::ptr::copy(src, dst, self.tail_len);
+            let ptr = vec.as_mut_ptr();
+            core::ptr::copy(
+                ptr.add(self.tail_start),
+                ptr.add(new_tail_start),
+                self.tail_len
+            );
         }
         self.tail_start = new_tail_start;
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1099,6 +1099,7 @@ impl<T, const N: usize> SmallVec<T, N> {
         if len == self.capacity() {
             self.reserve(1);
         }
+        debug_assert!(len < self.capacity());
 
         // SAFETY: `len < capacity` after the reserve,
         //         so the offset stays in bounds of the allocation.
@@ -1112,8 +1113,6 @@ impl<T, const N: usize> SmallVec<T, N> {
             // This block is an exact copy of `self.set_len`.
             // We have to do this so that Miri doesn't report a "Stacked
             // Borrows" rule violation. See PR/406
-
-            debug_assert!(len < self.capacity());
             // SAFETY: we have wrote the value to the address already
             unsafe {
                 self.len.add(1);
@@ -1434,6 +1433,7 @@ impl<T, const N: usize> SmallVec<T, N> {
             assert_failed(index, len);
         }
         self.reserve(1);
+        debug_assert!(len < self.capacity());
 
         // SAFETY: `index <= len <= capacity`,
         //         so the offset stays in bounds of the allocation.
@@ -1456,7 +1456,6 @@ impl<T, const N: usize> SmallVec<T, N> {
             // We have to do this so that Miri doesn't report a "Stacked
             // Borrows" rule violation. See PR/406
 
-            debug_assert!(len < self.capacity());
             // SAFETY: we have wrote the value to the address already
             unsafe {
                 self.len.add(1);

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -212,6 +212,22 @@ fn splice() {
 }
 
 #[test]
+fn splice_inline_fill_then_move_tail_ub_test() {
+    let mut v: SmallVec<Box<usize>, 16> = (0..6).map(Box::new).collect();
+    assert!(!v.spilled());
+    let out: Vec<usize> = v
+        .splice(1..3, (100..103).map(Box::new))
+        .map(|b| *b)
+        .collect();
+    assert_eq!(out, [1, 2]);
+    assert_eq!(
+        v.iter().map(|b| **b).collect::<Vec<usize>>(),
+        [0, 100, 101, 102, 3, 4, 5]
+    );
+    assert!(!v.spilled());
+}
+
+#[test]
 fn into_iter() {
     let mut v: SmallVec<u8, 2> = SmallVec::new();
     v.push(3);


### PR DESCRIPTION
I found these using my internal UB static analyzer project:
```csv
location,category,confidence,function,crate,kind,cwe,always,reason
src/lib.rs:538:5,aliasing,,"<Splice<'_, I, N> as core::ops::Drop>::drop",smallvec,ub,662,no,reached through a call
src/lib.rs:402:13,aliasing,5,"Drain::<'_, T, N>::move_tail",smallvec,ub,662,no,a pointer is used after the access at src/lib.rs:401:27 invalidated its borrow under Stacked Borrows
src/lib.rs:1421:5,aliasing,,"SmallVec::<T, N>::insert",smallvec,ub,662,no,reached through a call
src/lib.rs:1472:9,aliasing,5,"SmallVec::<T, N>::insert_mut",smallvec,ub,662,no,"a mutable reference reborrowed from a pointer whose borrow was frozen by the access at src/lib.rs:1462:33 escapes, so the caller's first write through it is undefined behavior"
src/lib.rs:1094:5,aliasing,,"SmallVec::<T, N>::push",smallvec,ub,662,no,reached through a call
src/lib.rs:1129:9,aliasing,5,"SmallVec::<T, N>::push_mut",smallvec,ub,662,no,"a mutable reference reborrowed from a pointer whose borrow was frozen by the access at src/lib.rs:1119:33 escapes, so the caller's first write through it is undefined behavior"
```

The new test currently fails with miri with following:
```
test splice_inline_fill_then_move_tail_ub_test ... error: Undefined Behavior: attempting a read access using <1314702> at alloc393314[0x20], but that tag does not exist in the borrow stack for this location
   --> src/lib.rs:563:17
    |
563 |                 self.drain.move_tail(lower_bound);
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this error occurs as part of an access at alloc393314[0x20..0x38]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
help: <1314702> was created by a SharedReadOnly retag at offsets [0x8..0x88]
   --> src/rawsmallvec.rs:66:19
    |
 66 |         (unsafe { &raw const self.inline }).cast()
    |                   ^^^^^^^^^^^^^^^^^^^^^^
help: <1314702> was later invalidated at offsets [0x0..0x88] by a Unique function-entry retag inside this call
   --> src/lib.rs:401:23
    |
401 |             let dst = vec.as_mut_ptr().add(new_tail_start);
    |                       ^^^^^^^^^^^^^^^^
    = note: this is on thread `splice_inline_f`
```

This simply fixes the reborrow which invalidates the first borrowed pointer(aliasing bug).
The second debug_assert!  commit is technically not ub, but the assert must be able to catch the bug before memory violation happens(write to the memory location).