### PR TITLE
Refactor `PartialEq` implementations

### DIFF
--- a/src/comparisons.rs
+++ b/src/comparisons.rs
@@ -16,8 +16,6 @@ macro_rules! __impl_slice_eq1 {
         {
             #[inline]
             fn eq(&self, other: &$rhs) -> bool { self[..] == other[..] }
-            #[inline]
-            fn ne(&self, other: &$rhs) -> bool { self[..] != other[..] }
         }
     };
 }

--- a/src/comparisons.rs
+++ b/src/comparisons.rs
@@ -1,59 +1,57 @@
-use crate::SmallVec;
+use {
+    crate::SmallVec,
+    alloc::{
+        borrow::Cow,
+        collections::VecDeque,
+        vec::Vec
+    }
+};
 
-impl<T, U, const N: usize, const M: usize> PartialEq<SmallVec<U, M>> for SmallVec<T, N>
+macro_rules! __impl_slice_eq1 {
+    ([$($vars:tt)*] $lhs:ty, $rhs:ty $(where $ty:ty: $bound:ident)?) => {
+        impl<T, U, $($vars)*> PartialEq<$rhs> for $lhs
+        where
+            T: PartialEq<U>,
+            $($ty: $bound)?
+        {
+            #[inline]
+            fn eq(&self, other: &$rhs) -> bool { self[..] == other[..] }
+            #[inline]
+            fn ne(&self, other: &$rhs) -> bool { self[..] != other[..] }
+        }
+    };
+}
+
+__impl_slice_eq1! { [const N: usize, const M: usize] SmallVec<T, M>, SmallVec<U, N> }
+__impl_slice_eq1! { [const N: usize, const M: usize] SmallVec<T, M>, [U; N] }
+__impl_slice_eq1! { [const N: usize, const M: usize] SmallVec<T, M>, &[U; N] }
+__impl_slice_eq1! { [const N: usize] SmallVec<T, N>, [U] }
+__impl_slice_eq1! { [const N: usize] SmallVec<T, N>, &[U] }
+__impl_slice_eq1! { [const N: usize] SmallVec<T, N>, &mut [U] }
+__impl_slice_eq1! { [const N: usize] [T], SmallVec<U, N> }
+__impl_slice_eq1! { [const N: usize] &[T], SmallVec<U, N> }
+__impl_slice_eq1! { [const N: usize] &mut [T], SmallVec<U, N> }
+__impl_slice_eq1! { [const N: usize] Vec<T>, SmallVec<U, N> }
+__impl_slice_eq1! { [const N: usize] SmallVec<T, N>, Vec<U> }
+__impl_slice_eq1! { [const N: usize] Cow<'_, [T]>, SmallVec<U, N> where T: Clone }
+__impl_slice_eq1! { [const N: usize] SmallVec<T, N>, Cow<'_, [U]> where U: Clone }
+
+impl<T, U, const N: usize> PartialEq<SmallVec<U, N>> for VecDeque<T>
 where T: PartialEq<U>
 {
     #[inline]
-    fn eq(&self, other: &SmallVec<U, M>) -> bool {
-        self.as_slice().eq(other.as_slice())
+    fn eq(&self, other: &SmallVec<U, N>) -> bool {
+        let other = other.as_slice();
+        if self.len() != other.len() {
+            return false;
+        }
+        let (sa, sb) = self.as_slices();
+        let (oa, ob) = other[..].split_at(sa.len());
+        sa == oa && sb == ob
     }
 }
+
 impl<T, const N: usize> Eq for SmallVec<T, N> where T: Eq {}
-
-impl<T, U, const N: usize, const M: usize> PartialEq<[U; M]> for SmallVec<T, N>
-where T: PartialEq<U>
-{
-    #[inline]
-    fn eq(&self, other: &[U; M]) -> bool {
-        self[..] == other[..]
-    }
-}
-
-impl<T, U, const N: usize, const M: usize> PartialEq<&[U; M]> for SmallVec<T, N>
-where T: PartialEq<U>
-{
-    #[inline]
-    fn eq(&self, other: &&[U; M]) -> bool {
-        self[..] == other[..]
-    }
-}
-
-impl<T, U, const N: usize> PartialEq<[U]> for SmallVec<T, N>
-where T: PartialEq<U>
-{
-    #[inline]
-    fn eq(&self, other: &[U]) -> bool {
-        self[..] == other[..]
-    }
-}
-
-impl<T, U, const N: usize> PartialEq<&[U]> for SmallVec<T, N>
-where T: PartialEq<U>
-{
-    #[inline]
-    fn eq(&self, other: &&[U]) -> bool {
-        self[..] == other[..]
-    }
-}
-
-impl<T, U, const N: usize> PartialEq<&mut [U]> for SmallVec<T, N>
-where T: PartialEq<U>
-{
-    #[inline]
-    fn eq(&self, other: &&mut [U]) -> bool {
-        self[..] == other[..]
-    }
-}
 
 impl<T, const N: usize> PartialOrd for SmallVec<T, N>
 where T: PartialOrd


### PR DESCRIPTION

* Introduces the same macro `alloc` uses for implementing `PartialEq` for its linear data structures, removing a bit of boilerplate.
* Some implementations of `PartialEq` that `Vec` has but `SmallVec` has not are implemented,
  making it easer to use `SmallVec` as a drop-in replacement for `Vec`.
* Adds `PartialEq` implementations for `Vec`, such that comparisons like `smallvec == vec` work
  without having to call `as_slice` or indexing.